### PR TITLE
Backfill emotes directory

### DIFF
--- a/chat_archiver/chat_archiver/main.py
+++ b/chat_archiver/chat_archiver/main.py
@@ -13,12 +13,11 @@ from calendar import timegm
 from collections import defaultdict
 from datetime import datetime
 from itertools import count
-from uuid import uuid4
 
 import gevent.event
 import gevent.queue
 
-from common import ensure_directory, listdir, rename
+from common import atomic_write, listdir
 from common.chat import BATCH_INTERVAL, format_batch, get_batch_files, merge_messages
 
 from girc import Client
@@ -273,14 +272,6 @@ class Archiver(object):
 
 	def stop(self):
 		self.client.stop()
-
-
-def atomic_write(filepath, content):
-	temp_path = "{}.{}.temp".format(filepath, uuid4())
-	ensure_directory(filepath)
-	with open(temp_path, 'wb') as f:
-		f.write(content)
-	rename(temp_path, filepath)
 
 
 _EMOTES_RUNNING = {} # map (base_dir, emote id, theme, scale) -> in-progress greenlet fetching that path

--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -151,6 +151,9 @@
   // Set to null to disable.
   backfill_max_hours_ago:: 24 * 30 * 6, // approx 6 months
 
+  // Extra directories (besides segments) to backfill
+  backfill_dirs:: ["emotes"],
+
   // The spreadsheet id and worksheet names for sheet sync to act on
   sheet_id:: "your_id_here",
   worksheets:: ["Tech Test & Preshow"] + ["Day %d" % n for n in std.range(1, 8)],
@@ -256,6 +259,7 @@
       [
         "--base-dir", "/mnt",
         "--qualities", std.join(",", $.qualities + (if $.chat_archiver.backfill then ["chat"] else [])),
+        "--extras", std.join(",", $.backfill_dirs),
         "--static-nodes", std.join(",", $.peers),
         "--backdoor-port", std.toString($.backdoor_port),
         "--node-database", $.db_connect,

--- a/restreamer/restreamer/main.py
+++ b/restreamer/restreamer/main.py
@@ -155,6 +155,23 @@ def list_segments(channel, quality, hour):
 	return json.dumps(list_segment_files(path, include_tombstones=tombstones, include_chat=True))
 
 
+@app.route('/extras/<dir>')
+@request_stats
+@has_path_args
+def list_extras(dir):
+	"""List all files under directory recursively. All paths returned are relative to dir.
+	Files can be fetched under /segments/<dir>/<path>.
+	Note this is only intended for extra files, and not for segments.
+	"""
+	root = os.path.join(app.static_folder, dir)
+	result = []
+	for path, subdirs, files in os.walk(root):
+		relpath = os.path.relpath(path, root)
+		for file in files:
+			result.append(os.path.normpath(os.path.join(relpath, file)))
+	return json.dumps(result)
+
+
 @app.route('/thumbnail-templates')
 def list_thumbnail_templates():
 	"""List available thumbnail templates. Returns a JSON list of names."""


### PR DESCRIPTION
We define a concept of "extras" which are non-segment directories that we want to backfill.
Right now the only "extras" directory is "emotes" but this might later include other things.

Restreamer has learned how to list these files, and backiller can backfill them.
Note that we still assume files with the same name have identical content
ie. if we already have a file, we don't re-download it.