### PR TITLE
downloader: Add optional ability to authenticate when getting master playlist

### DIFF
--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -114,6 +114,10 @@
   db_readonly_password:: "volunteer", // don't use default in production. Must not contain ' or \ as these are not escaped.  
   db_standby:: false, // set to true to have this database replicate another server
 
+  // Path to a file containing a twitch OAuth token to use when downloading streams.
+  // This is optional (null to omit) but may be helpful to bypass ads.
+  downloader_creds_file:: null,
+
   // Path to a JSON file containing google credentials for cutter as keys
   // 'client_id', 'client_secret' and 'refresh_token'.
   cutter_creds_file:: "./google_creds.json",
@@ -284,9 +288,10 @@
         "--base-dir", "/mnt",
         "--qualities", std.join(",", $.qualities),
         "--backdoor-port", std.toString($.backdoor_port),
-      ],
+      ] + if $.downloader_creds_file != null then ["--auth-file", "/token"] else [],
       // Mount the segments directory at /mnt
-      volumes: ["%s:/mnt" % $.segments_path],
+      volumes: ["%s:/mnt" % $.segments_path]
+        + if $.downloader_creds_file != null then ["%s:/token" % $.downloader_creds_file] else [],
       // If the application crashes, restart it.
       restart: "on-failure",
       // Expose on the configured host port by mapping that port to the default

--- a/downloader/downloader/twitch.py
+++ b/downloader/downloader/twitch.py
@@ -10,7 +10,7 @@ from . import hls_playlist
 logger = logging.getLogger(__name__)
 
 
-def get_access_token(channel, session):
+def get_access_token(channel, session, auth_token):
 	request = {
 		"operationName": "PlaybackAccessToken",
 		"extensions": {
@@ -27,10 +27,13 @@ def get_access_token(channel, session):
 			"playerType": "site"
 		}
 	}
+	headers = {'Client-ID': 'kimne78kx3ncx6brgo4mv6wki5h1ko'}
+	if auth_token is not None:
+		headers["Authorization"] = "OAuth {}".format(auth_token)
 	resp = session.post(
 		"https://gql.twitch.tv/gql",
 		json=request,
-		headers={'Client-ID': 'kimne78kx3ncx6brgo4mv6wki5h1ko'},
+		headers=headers,
 		metric_name='get_access_token',
 	)
 	resp.raise_for_status()
@@ -38,11 +41,11 @@ def get_access_token(channel, session):
 	return data['signature'], data['value']
 
 
-def get_master_playlist(channel, session=None):
+def get_master_playlist(channel, session=None, auth_token=None):
 	"""Get the master playlist for given channel from twitch"""
 	if session is None:
 		session = InstrumentedSession()
-	sig, token = get_access_token(channel, session)
+	sig, token = get_access_token(channel, session, auth_token)
 	resp = session.get(
 		"https://usher.ttvnw.net/api/channel/hls/{}.m3u8".format(channel),
 		headers={


### PR DESCRIPTION
Authenticating to a particular twitch account can give benefits, most notably not being served ads.