### PR TITLE
thrimbletrimmer: Change default download type to smart

### DIFF
--- a/thrimbletrimmer/edit.html
+++ b/thrimbletrimmer/edit.html
@@ -282,11 +282,14 @@
 			<div id="download">
 				<label for="download-type-select">Download type:</label>
 				<select id="download-type-select">
-					<option value="rough" selected>
-						Rough (fastest, pads start and end by a few seconds)
+					<option value="smart" selected>
+						Smart (experimental but preferred option)
+					</option>
+					<option value="rough">
+						Rough (raw content, pads start and end by a few seconds)
 					</option>
 					<option value="fast">
-						Fast (may have artifacts a few seconds in from start and end)
+						Fast (deprecated, use if smart is broken)
 					</option>
 					<option value="mpegts">MPEG-TS (slow, consumes server resources)</option>
 				</select>

--- a/thrimbletrimmer/scripts/stream.js
+++ b/thrimbletrimmer/scripts/stream.js
@@ -148,7 +148,7 @@ function generateDownloadURL(startTime, endTime, downloadType, allowHoles, quali
 
 function updateDownloadLink() {
 	const downloadLink = document.getElementById("download");
-	const downloadURL = generateDownloadURL(getStartTime(), getEndTime(), "rough", true, "source");
+	const downloadURL = generateDownloadURL(getStartTime(), getEndTime(), "smart", true, "source");
 	downloadLink.href = downloadURL;
 }
 


### PR DESCRIPTION
The new smart cut type avoids artifacting/playing issues that happen with fast cuts or multi-range rough cuts.

However it is new and experimental so we keep the old options available as backups.