### PR TITLE
chat_archiver: Watch multiple channels at once

### DIFF
--- a/chat_archiver/chat_archiver/main.py
+++ b/chat_archiver/chat_archiver/main.py
@@ -47,8 +47,9 @@ COMMANDS = DELAYED_COMMANDS + [
 ]
 
 # Assume we're never more than this amount of time behind the server time
-# Worst case if too low: multiple output files for same batch that need merging later
-MAX_SERVER_LAG = 30
+# Worst case if too low: multiple output files for same batch that need merging later.
+# Should be greater than MAX_DELAY.
+MAX_SERVER_LAG = 60
 
 # When guessing when a non-timestamped event occurred, pad the possible range
 # by up to this amount before and after our best guess

--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -528,7 +528,7 @@
     [if $.enabled.chat_archiver then "chat_archiver"]: {
       image: $.get_image("chat_archiver"),
       restart: "always",
-      command: [$.chat_archiver.channel, $.chat_archiver.user, "/token", "--name", $.localhost],
+      command: [$.chat_archiver.user, "/token", $.chat_archiver.channel, "--name", $.localhost],
       volumes: ["%s:/mnt" % $.segments_path, "%s:/token" % $.chat_archiver.token_path],
       [if "chat_archiver" in $.ports then "ports"]: ["%s:8008" % $.ports.chat_archiver],
       environment: $.env,

--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -185,9 +185,6 @@
   ],
 
   chat_archiver:: {
-    // We currently only support archiving chat from one channel at once.
-    // This defaults to the first channel in the $.channels list.
-    channel: $.clean_channels[0],
     // Twitch user to log in as and path to oauth token
     user: "dbvideostriketeam",
     token_path: "./chat_token.txt",
@@ -528,7 +525,7 @@
     [if $.enabled.chat_archiver then "chat_archiver"]: {
       image: $.get_image("chat_archiver"),
       restart: "always",
-      command: [$.chat_archiver.user, "/token", $.chat_archiver.channel, "--name", $.localhost],
+      command: [$.chat_archiver.user, "/token", "--name", $.localhost] + $.clean_channels,
       volumes: ["%s:/mnt" % $.segments_path, "%s:/token" % $.chat_archiver.token_path],
       [if "chat_archiver" in $.ports then "ports"]: ["%s:8008" % $.ports.chat_archiver],
       environment: $.env,


### PR DESCRIPTION
Previously, the chat archiver could only watch a single channel.
This works ok for our purposes since there's really only one channel we care about,
but it means we can miss chatter on test channels or other weird situations.

This PR allows chat archiver to take multiple channels as arguments,
and connect to all of them with one connection. They are still batched seperately.

It also updates the docker-compose file to automatically watch all channels
we give to the downloader.