### PR TITLE
Get archive cuts working and integrated with the sheet

### DIFF
--- a/common/common/segments.py
+++ b/common/common/segments.py
@@ -665,7 +665,7 @@ def archive_cut_segments(segment_ranges, ranges, tempdir):
 	which the caller should then do something with (probably either read then delete, or rename).
 	"""
 	# don't re-encode anything, just put it into an MKV container
-	encode_args = ["-c", "copy", "-f", "mkv"]
+	encode_args = ["-c", "copy", "-f", "matroska"]
 	# We treat multiple segment ranges as having an explicit discontinuity between them.
 	# So we apply split_contiguous() to each range, then flatten.
 	contiguous_ranges = []
@@ -705,7 +705,7 @@ def archive_cut_segments(segment_ranges, ranges, tempdir):
 			raise
 		else:
 			# Success, inform caller of tempfile. It's now their responsibility to delete.
-			yield tempfile
+			yield tempfile_name
 
 
 @timed('waveform')

--- a/cutter/cutter/main.py
+++ b/cutter/cutter/main.py
@@ -477,7 +477,7 @@ class Cutter(object):
 				# Assumed error is not retryable
 				raise UploadError("Error while generating thumbnail: {}".format(ex), retryable=False)
 
-			if len(thumbnail) > 2 * 2**20:
+			if thumbnail is not None and len(thumbnail) > 2 * 2**20:
 				self.logger.warning("Aborting upload as thumbnail is too big ({}MB, max 2MB)".format(len(thumbnail) / 2.**20))
 				raise UploadError("Thumbnail is too big ({}MB, max 2MB)".format(len(thumbnail) / 2.**20), retryable=False)
 

--- a/cutter/cutter/upload_backends.py
+++ b/cutter/cutter/upload_backends.py
@@ -353,7 +353,8 @@ class LocalArchive(Local):
 	"""Similar to Local() but does archive cuts. See archive_cut_segments()."""
 	encoding_settings = "archive"
 
-	def upload_video(self, title, description, tags, public, tempfiles):
+	def upload_video(self, title, description, tags, public, data):
+		tempfiles = data
 		# make title safe by removing offending characters, replacing with '-'
 		safe_title = re.sub('[^A-Za-z0-9_]', '-', title)
 		# To aid in finding the "latest" version if re-edited, prefix with current time.
@@ -362,6 +363,7 @@ class LocalArchive(Local):
 		common.ensure_directory(os.path.join(self.path, video_dir))
 		for n, tempfile in enumerate(tempfiles):
 			filepath = os.path.join(self.path, video_dir, "{}-{}.mkv".format(safe_title, n))
+			common.ensure_directory(filepath)
 			# We're assuming these are on the same filesystem. This may not always be true
 			# but it will be in our normal setup. If we ever need this in the future, we'll fix it then.
 			os.rename(tempfile, filepath)

--- a/cutter/cutter/upload_backends.py
+++ b/cutter/cutter/upload_backends.py
@@ -305,8 +305,8 @@ class Local(UploadBackend):
 
 	def upload_video(self, title, description, tags, public, data):
 		video_id = str(uuid.uuid4())
-		# make title safe by removing offending characters, replacing with '-'
-		safe_title = re.sub('[^A-Za-z0-9_]', '-', title)
+		# make title safe by removing offending characters, replacing with '_'
+		safe_title = re.sub('[^A-Za-z0-9_]', '_', title)
 		ext = 'ts'
 		filename = '{}-{}.{}'.format(safe_title, video_id, ext)
 		filepath = os.path.join(self.path, filename)
@@ -355,8 +355,8 @@ class LocalArchive(Local):
 
 	def upload_video(self, title, description, tags, public, data):
 		tempfiles = data
-		# make title safe by removing offending characters, replacing with '-'
-		safe_title = re.sub('[^A-Za-z0-9_]', '-', title)
+		# make title safe by removing offending characters, replacing with '_'
+		safe_title = re.sub('[^A-Za-z0-9_]', '_', title)
 		# To aid in finding the "latest" version if re-edited, prefix with current time.
 		prefix = str(time.time())
 		video_dir = "{}-{}".format(prefix, safe_title)


### PR DESCRIPTION
This adds a `archive_worksheet` option to the docker-compose.
This specifies a worksheet where the torrent videos are defined.

We can then edit those videos the same way we do ones on the normal sheet.

They are treated differently in a few ways which required custom support:
* sheetsync: Different order of columns, with some not present
* thrimshim: Different default upload location, allow holes, no thumbnail, no title/description stuff.
* cutter: Uses an "archive cut" (merged already, but this fixes some bugs) that saves locally, with one file per continuous part of the stream,
  ie. it splits into a new file for every hole.