### PR TITLE
Multiple improvements to performance and responsiveness of restreamer

### DIFF
--- a/common/common/segments.py
+++ b/common/common/segments.py
@@ -535,10 +535,11 @@ def fast_cut_range(segments, start, end, fixts=None):
 	first = segments[0] if cut_start else None
 	last = segments[-1] if cut_end else None
 
-	for segment in segments:
+	for i, segment in enumerate(segments):
 		# Since long smart cuts can be CPU and disk bound for quite a while,
 		# yield to give other things a chance to run.
-		gevent.idle()
+		if i % 1000 == 0:
+			gevent.idle()
 
 		if segment is None:
 			logging.debug("Skipping discontinuity while cutting")

--- a/restreamer/restreamer/generate_hls.py
+++ b/restreamer/restreamer/generate_hls.py
@@ -3,6 +3,7 @@ import os
 import urllib.parse
 from collections import Counter
 
+import gevent
 
 def generate_master(playlists):
 	"""Generate master playlist. Playlists arg should be a map {name: url}.
@@ -69,6 +70,8 @@ def generate_media(segments, base_url):
 		segments = segments[1:]
 
 	for segment in segments:
+		# For very large playlists, give other things a chance to run
+		gevent.idle()
 		if segment is None:
 			# Discontinuity. Adding this tag tells the client that we've missed something
 			# and it should start decoding fresh on the next segment. This is required when

--- a/restreamer/restreamer/generate_hls.py
+++ b/restreamer/restreamer/generate_hls.py
@@ -69,9 +69,10 @@ def generate_media(segments, base_url):
 	if segments and segments[0] is None:
 		segments = segments[1:]
 
-	for segment in segments:
+	for i, segment in enumerate(segments):
 		# For very large playlists, give other things a chance to run
-		gevent.idle()
+		if i % 1000 == 0:
+			gevent.idle()
 		if segment is None:
 			# Discontinuity. Adding this tag tells the client that we've missed something
 			# and it should start decoding fresh on the next segment. This is required when

--- a/restreamer/restreamer/main.py
+++ b/restreamer/restreamer/main.py
@@ -275,31 +275,32 @@ def generate_media_playlist(channel, quality):
 	if end - start > datetime.timedelta(hours=12) and ('start' not in request.args or 'end' not in request.args):
 		return "Implicit range may not be longer than 12 hours", 400
 
+	cache_key = (hours_path, start, end)
+	if cache_key in _media_playlist_cache:
+		return _media_playlist_cache[cache_key].get()
+
 	# get_best_segments requires start be before end, special case that as no segments
 	# (not an error because someone might ask for a specific start, no end, but we ended up with
 	# end before start because that's the latest time we have)
 	if start < end:
-		cache_key = (hours_path, start, end)
-		if cache_key in _media_playlist_cache:
-			segments = _media_playlist_cache[cache_key].get()
-		else:
-			result = gevent.event.AsyncResult()
-			try:
-				# Note we don't populate the cache until we're in the try block,
-				# so there is no point where an exception won't be transferred to the result.
-				_media_playlist_cache[cache_key] = result
-				segments = list(get_best_segments(hours_path, start, end))
-				result.set(segments)
-			except BaseException as ex:
-				result.set_exception(ex)
-				raise
-			# Now we're done, remove the async result so a fresh request can start.
-			assert _media_playlist_cache.pop(cache_key) is result, "Got someone else's AsyncResult"
+		segments = get_best_segments(hours_path, start, end)
 	else:
 		# Note the None to indicate there was a "hole" at both start and end
 		segments = [None]
 
-	return generate_hls.generate_media(segments, os.path.join(app.static_url_path, channel, quality))
+	result = gevent.event.AsyncResult()
+	try:
+		# Note we don't populate the cache until we're in the try block,
+		# so there is no point where an exception won't be transferred to the result.
+		_media_playlist_cache[cache_key] = result
+		playlist = "".join(generate_hls.generate_media(segments, os.path.join(app.static_url_path, channel, quality)))
+		result.set(playlist)
+	except BaseException as ex:
+		result.set_exception(ex)
+		raise
+	# Now we're done, remove the async result so a fresh request can start.
+	assert _media_playlist_cache.pop(cache_key) is result, "Got someone else's AsyncResult"
+	return playlist
 
 
 @app.route('/cut/<channel>/<quality>.ts')


### PR DESCRIPTION
when requesting the same very large playlist over and over.

Main highlights:
* generating the hls playlist is now a streaming result
* if multiple calls for the same time range come in concurrently, we only run it once
* we yield to the event loop in more places to avoid locking up other requests