### PR TITLE
thrimbletrimmer: Validate chapter titles are ascii only

### DIFF
--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -829,7 +829,7 @@ function validateChapterDescription(chapterDescField) {
 		// We don't know what chars are safe outside the ascii range, so we just warn on any of them.
 		// We know emoji are not safe.
 		chapterDescField.classList.add("input-error");
-		chapterDescField.title = "Chapter descriptions with non-ascii characters may cause issues, proceed with caution";
+		chapterDescField.title = "Chapter descriptions with non-ascii characters may cause issues; proceed with caution";
 	} else {
 		chapterDescField.classList.remove("input-error");
 		chapterDescField.title = "";

--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -825,6 +825,11 @@ function validateChapterDescription(chapterDescField) {
 	if (chapterDesc.indexOf("<") !== -1 || chapterDesc.indexOf(">") !== -1) {
 		chapterDescField.classList.add("input-error");
 		chapterDescField.title = "Chapter description may not contain angle brackets (< or >)";
+	} else if (Array.from(chapterDesc).some(c => c.charCodeAt(0) > 127)) { // any char is non-ascii
+		// We don't know what chars are safe outside the ascii range, so we just warn on any of them.
+		// We know emoji are not safe.
+		chapterDescField.classList.add("input-error");
+		chapterDescField.title = "Chapter descriptions with non-ascii characters may cause issues, proceed with caution";
 	} else {
 		chapterDescField.classList.remove("input-error");
 		chapterDescField.title = "";


### PR DESCRIPTION
We are not sure what characters are allowed in chapter titles.
Emoji seem to be disallowed. It is unknown whether things like accents or smart quotes are allowed.
To be conservative, we warn if there are any non-ascii characters in the chapter title.

Fixes https://github.com/dbvideostriketeam/wubloader/issues/325