### PR TITLE
Support video transitions

### DIFF
--- a/cutter/cutter/main.py
+++ b/cutter/cutter/main.py
@@ -419,7 +419,7 @@ class Cutter(object):
 						upload_backend.encoding_settings,
 					))
 					cut = full_cut_segments(
-						job.segment_ranges, job.video_ranges,
+						job.segment_ranges, job.video_ranges, job.video_transitions,
 						upload_backend.encoding_settings, stream=upload_backend.encoding_streamable,
 					)
 

--- a/cutter/cutter/main.py
+++ b/cutter/cutter/main.py
@@ -396,23 +396,24 @@ class Cutter(object):
 			nonlocal upload_finished
 
 			try:
-				if upload_backend.encoding_settings in ("fast", "smart", "archive"):
+				if upload_backend.encoding_settings in ("fast", "smart"):
 					self.logger.debug(f"Using {upload_backend.encoding_settings} cut")
-					if any(transition is not None for transition in job.video_transitions):
-						raise ValueError("Fast cuts do not support complex transitions")
-
 					cut_fn = {
 						"fast": fast_cut_segments,
 						"smart": smart_cut_segments,
-						# Note archive cuts return a list of filenames instead of data chunks.
-						# We assume the upload location expects this.
-						# We use segments_path as a tempdir path under the assumption that:
-						# a) it has plenty of space
-						# b) for a Local upload location, it will be on the same filesystem as the
-						#    final desired path.
-						"archive": lambda sr, vr: archive_cut_segments(sr, vr, self.segments_path),
 					}[upload_backend.encoding_settings]
-					cut = cut_fn(job.segment_ranges, job.video_ranges)
+					cut = cut_fn(job.segment_ranges, job.video_ranges, job.video_transitions)
+				elif upload_backend.encoding_settings == "archive":
+					self.logger.debug("Using archive cut")
+					if any(transition is not None for transition in job.video_transitions):
+						raise ValueError("Archive cuts do not support complex transitions")
+					# Note archive cuts return a list of filenames instead of data chunks.
+					# We assume the upload location expects this.
+					# We use segments_path as a tempdir path under the assumption that:
+					# a) it has plenty of space
+					# b) for a Local upload location, it will be on the same filesystem as the
+					#    final desired path.
+					cut = archive_cut_segments(sr, vr, self.segments_path)
 				else:
 					self.logger.debug("Using encoding settings for {} cut: {}".format(
 						"streamable" if upload_backend.encoding_streamable else "non-streamable",

--- a/cutter/cutter/main.py
+++ b/cutter/cutter/main.py
@@ -418,11 +418,8 @@ class Cutter(object):
 						"streamable" if upload_backend.encoding_streamable else "non-streamable",
 						upload_backend.encoding_settings,
 					))
-					if len(job.video_ranges) > 1:
-						raise ValueError("Full cuts do not support multiple ranges")
-					range = job.video_ranges[0]
 					cut = full_cut_segments(
-						job.segment_ranges[0], range.start, range.end,
+						job.segment_ranges, job.video_ranges,
 						upload_backend.encoding_settings, stream=upload_backend.encoding_streamable,
 					)
 

--- a/restreamer/restreamer/main.py
+++ b/restreamer/restreamer/main.py
@@ -415,13 +415,9 @@ def cut(channel, quality):
 			return "Cannot do rough cut with transitions", 400
 		return Response(rough_cut_segments(segment_ranges, ranges), mimetype='video/MP2T')
 	elif type == 'fast':
-		if has_transitions:
-			return "Cannot do fast cut with transitions", 400
-		return Response(fast_cut_segments(segment_ranges, ranges), mimetype='video/MP2T')
+		return Response(fast_cut_segments(segment_ranges, ranges, transitions), mimetype='video/MP2T')
 	elif type == 'smart':
-		if has_transitions:
-			return "Cannot do smart cut with transitions", 400
-		return Response(smart_cut_segments(segment_ranges, ranges), mimetype='video/MP2T')
+		return Response(smart_cut_segments(segment_ranges, ranges, transitions), mimetype='video/MP2T')
 	elif type in ('mpegts', 'mp4'):
 		if type == 'mp4':
 			return "mp4 type has been disabled due to the load it causes", 400

--- a/restreamer/restreamer/main.py
+++ b/restreamer/restreamer/main.py
@@ -400,10 +400,7 @@ def cut(channel, quality):
 		# encode as high-quality, without wasting too much cpu on encoding
 		stream, muxer, mimetype = (True, 'mpegts', 'video/MP2T') if type == 'mpegts' else (False, 'mp4', 'video/mp4')
 		encoding_args = ['-c:v', 'libx264', '-preset', 'ultrafast', '-crf', '0', '-f', muxer]
-		if len(ranges) > 1:
-			return "full cut does not support multiple ranges at this time", 400
-		start, end = ranges[0]
-		return Response(full_cut_segments(segment_ranges[0], start, end, encoding_args, stream=stream), mimetype=mimetype)
+		return Response(full_cut_segments(segment_ranges, ranges, encoding_args, stream=stream), mimetype=mimetype)
 	else:
 		return "Unknown type {!r}".format(type), 400
 


### PR DESCRIPTION
This PR has quite a few changes to how cutting is done, in support of two new features:
- For full cuts, support multiple ranges (previously they only allowed one range)
- For fast, smart and full cuts, support cuts with transitions between ranges

This required rewriting ffmpeg handling considerably.
In the process I was able to build slightly higher level abstractions around calling ffmpeg which I think is a win overall.
The simple cut functions (eg. to build a waveform or extract a frame) are considerably easier.

It may be best to review this commit by commit - the first few commits are setting up the abstractions
I then use for rewriting the fast and full cuts.

We support all transitions built into the `xfade` filter in ffmpeg, including basics like `fade`
but also many kinds of wipe. We also have two custom wipes, a star wipe and a clock wipe.

Audio is cross-faded over the same time period as the video transition - we may revisit this in the future
but this was the simplest option.

The cutter needed almost no changes to pass in the transitions correctly. The restreamer learned a new option to the `cut` endpoint to also take a number of transitions.