### PR TITLE
Allow setting a pinned first or last video in a playlist

### DIFF
--- a/playlist_manager/playlist_manager/main.py
+++ b/playlist_manager/playlist_manager/main.py
@@ -107,7 +107,7 @@ class PlaylistManager(object):
 		if not set([v.video_id for v in matching]) - set(self.playlist_state.get(playlist, [])):
 			logging.debug("All videos already in playlist, nothing to do")
 			return
-		# Refresh our playlist state, if nessecary.
+		# Refresh our playlist state, if necessary.
 		self.refresh_playlist(playlist)
 		# Get an updated list of new videos
 		new_videos = [

--- a/playlist_manager/playlist_manager/main.py
+++ b/playlist_manager/playlist_manager/main.py
@@ -104,18 +104,20 @@ class PlaylistManager(object):
 		]
 		logging.debug("Found {} matching videos for playlist {}".format(len(matching), playlist))
 		# If we have nothing to add, short circuit without doing any API calls to save quota.
-		if not set([v.video_id for v in matching]) - set(self.playlist_state.get(playlist, [])):
+
+		matching_video_ids = {video.video_id for video in matching}
+		playlist_video_ids = set(self.playlist_state.get(playlist, []))
+		if not (matching_video_ids - playlist_video_ids):
 			logging.debug("All videos already in playlist, nothing to do")
 			return
 		# Refresh our playlist state, if necessary.
 		self.refresh_playlist(playlist)
 		# Get an updated list of new videos
-		new_videos = [
-			video for video in matching
-			if video.video_id not in self.playlist_state[playlist]
-		]
+		matching_video_ids = {video.video_id for video in matching}
+		playlist_video_ids = set(self.playlist_state.get(playlist, []))
 		# It shouldn't matter, but just for clarity let's sort them by event order
-		new_videos.sort(key=lambda v: v.start_time)
+		new_videos = sorted(matching_video_ids - playlist_video_ids, key=lambda v: v.start_time)
+
 		# Insert each new video one at a time
 		logging.debug("Inserting new videos for playlist {}: {}".format(playlist, new_videos))
 		for video in new_videos:

--- a/playlist_manager/playlist_manager/main.py
+++ b/playlist_manager/playlist_manager/main.py
@@ -18,6 +18,13 @@ PlaylistConfig = namedtuple("Playlist", ["tags", "first_event_id", "last_event_i
 PlaylistEntry = namedtuple("PlaylistEntry", ["entry_id", "video_id"])
 
 
+class APIException(Exception):
+	"""Thrown when an API call fails. Exposes the HTTP status code."""
+	def __init__(self, message, code):
+		super().__init__(message)
+		self.code = code
+
+
 class PlaylistManager(object):
 
 	def __init__(self, dbmanager, api_client, upload_locations, playlist_tags):
@@ -246,9 +253,9 @@ class YoutubeAPI(object):
 				metric_name="playlist_insert",
 			)
 		if not resp.ok:
-			raise Exception("Failed to insert {video_id} at index {index} of {playlist} with {resp.status_code}: {resp.content}".format(
+			raise APIException("Failed to insert {video_id} at index {index} of {playlist} with {resp.status_code}: {resp.content}".format(
 				playlist=playlist_id, video_id=video_id, index=index, resp=resp,
-			))
+			), code=resp.status_code)
 		# TODO return entry_id from resp
 
 	def list_playlist(self, playlist_id):
@@ -272,9 +279,9 @@ class YoutubeAPI(object):
 			metric_name="playlist_list",
 		)
 		if not resp.ok:
-			raise Exception("Failed to list {playlist} (page_token={page_token!r}) with {resp.status_code}: {resp.content}".format(
+			raise APIException("Failed to list {playlist} (page_token={page_token!r}) with {resp.status_code}: {resp.content}".format(
 				playlist=playlist_id, page_token=page_token, resp=resp,
-			))
+			), code=resp.status_code)
 		return resp.json()
 
 

--- a/postgres/setup.sh
+++ b/postgres/setup.sh
@@ -147,6 +147,8 @@ CREATE TABLE playlists (
 	playlist_id TEXT PRIMARY KEY,
 	name TEXT NOT NULL,
 	tags TEXT[] NOT NULL,
+	first_event_id UUID REFERENCES events(id) ON DELETE SET NULL,
+	last_event_id UUID REFERENCES events(id) ON DELETE SET NULL,
 	show_in_description BOOLEAN NOT NULL
 );
 


### PR DESCRIPTION
Co-authored by @ZeldaZach
Fixes https://github.com/dbvideostriketeam/wubloader/issues/386

This adds two configurable properties to a playlist, specifying a "first" and "last" event id.
Both are optional.

When present, they cause the video associated with that event to always be placed first or last in playlist order, overriding the normal "by start time" ordering and working retroactively (ie. they'll be moved to the front/back if not there already).
The primary use case for this is supercuts, which we generally want to put at the end of a playlist even if the associated event row coincides with the first instance of the thing being supercut.
It may also prove useful eg. if we get a clean version of a repeating intro, which would best go at the front of a playlist.

While conceptually simple, this change required some signifigant refactoring of `playlist_manager` to plumb more data to where it was needed, for example needing to cache the playlist entry ids instead of just video ids.
Along the way we do some refactoring for clarity, most notably splitting the use of ambiguous variables named `playlist` into either:
- `playlist` (A list of entries)
- `playlist_id` (A string identifier)
- `playlist_config` (A named tuple containing playlist tags and first/last event ids)

This change does not incorporate any way to *set* these first/last event ids, which would likely be in sheetsync - however I don't really want to make further changes there until https://github.com/dbvideostriketeam/wubloader/issues/345 is complete.