### PR TITLE
Record in database when end time is "--"

### DIFF
--- a/common/common/database.py
+++ b/common/common/database.py
@@ -17,6 +17,7 @@ from psycogreen.gevent import patch_psycopg
 COMPOSITE_TYPES = [
 	"video_range",
 	"video_transition",
+	"end_time",
 ]
 COLUMN_CASTS = {
 	"video_ranges": "video_range[]",

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -26,12 +26,24 @@ CREATE TYPE thumbnail_mode as ENUM (
 	'CUSTOM'
 );
 
+-- The end time for an event can be unset, "--" or a timestamp.
+-- If dashed is true, value should be the same as start time (which may be NULL if start time is unset).
+-- Otherwise value is the value (which may be NULL if end time is unset).
+-- dashed should be non-NULL.
+CREATE TYPE end_time AS (
+	dashed BOOLEAN,
+	value TIMESTAMP
+)
+
 CREATE TABLE events (
 	id TEXT PRIMARY KEY,
 
 	sheet_name TEXT NOT NULL,
 	event_start TIMESTAMP,
-	event_end TIMESTAMP,
+	event_end end_time DEFAULT ROW(false, NULL) CHECK (
+		event_end.dashed IS NOT NULL
+		AND (event_end.dashed != TRUE OR event_end.value IS NOT DISTINCT FROM event_start)
+	),
 	category TEXT NOT NULL DEFAULT '',
 	description TEXT NOT NULL DEFAULT '',
 	submitter_winner TEXT NOT NULL DEFAULT '',


### PR DESCRIPTION
We need this so that reverse sync reproduces these values correctly.

To handle this in the database, we have a composite type (dashed: boolean, value: timestamp).
Value is always valid and is equivalent to the old timestamp column,
but must be equal to start_time if dashed is true.

The only place we directly reference this column outside sheetsync is thrimshim, where we
always consider the value only.