### PR TITLE
chat-archiver: Download media that is linked in chat

### DIFF
--- a/chat_archiver/chat_archiver/ensure_emotes.py
+++ b/chat_archiver/chat_archiver/ensure_emotes.py
@@ -4,7 +4,6 @@ gevent.monkey.patch_all()
 
 import argh
 import logging
-import json
 
 from chat_archiver.main import ensure_emotes, wait_for_ensure_emotes
 

--- a/chat_archiver/chat_archiver/keyed_group.py
+++ b/chat_archiver/chat_archiver/keyed_group.py
@@ -1,0 +1,27 @@
+
+"""A group of greenlets running tasks.
+Each task has a key. If a task with that key is already running,
+it is not re-run."""
+
+import gevent
+
+
+class KeyedGroup:
+	def __init__(self):
+		self.greenlets = {}
+
+	def spawn(self, key, func, *args, **kwargs):
+		if key not in self.greenlets:
+			self.greenlets[key] = gevent.spawn(self._wrapper, key, func, *args, **kwargs)
+		return self.greenlets[key]
+
+	def wait(self):
+		"""Blocks until all tasks started before wait() was called are finished."""
+		gevent.wait(self.greenlets.values())
+
+	def _wrapper(self, key, func, *args, **kwargs):
+		try:
+			return func(*args, **kwargs)
+		finally:
+			assert self.greenlets[key] is gevent.getcurrent()
+			del self.greenlets[key]

--- a/chat_archiver/chat_archiver/main.py
+++ b/chat_archiver/chat_archiver/main.py
@@ -354,7 +354,7 @@ URL_REGEX = re.compile(r"""
 	# Previous char is not a letter. This prevents eg. "foohttp://example.com"
 	# Also disallows / as the previous character, otherwise "file:///foo.bar/baz"
 	# can match on the "foo.bar/baz" part.
-	(?<! \w | / )
+	(?<! [\w/] )
 	# optional scheme, which must be http or https (we don't want other schemes)
 	(?P<scheme> https?:// )?
 	# Hostname, which must contain a dot. Single-part hostnames like "localhost" are valid
@@ -372,8 +372,8 @@ URL_REGEX = re.compile(r"""
 	# like that even though it's encoded when actually sent as a URL.
 	# Restricting this to letters prevents things like non-breaking spaces causing problems.
 	# For the same reason we also allow {} and [] which seem to show up often in paths.
-	(?P<path> / (\w | [!#$%&'()*+,./:;=?@_~{}-] | \[ | \] )* )?
-""", re.ASCII | re.VERBOSE | re.IGNORECASE)
+	(?P<path> / [\w!#$%&'()*+,./:;=?@_~{}\[\]-]* )?
+""", re.VERBOSE | re.IGNORECASE)
 
 
 _IMAGE_LINKS_RUNNING = KeyedGroup()

--- a/common/common/media.py
+++ b/common/common/media.py
@@ -64,7 +64,7 @@ def download_media(
 	output_dir,
 	max_size=128*2**20, # 128MiB
 	timeout=60,
-	content_types=("image", "video"),
+	content_types=("image", "video", "application/pdf"),
 	max_redirects=5,
 	retries=3,
 	retry_interval=1,

--- a/common/common/media.py
+++ b/common/common/media.py
@@ -14,7 +14,7 @@ import prometheus_client as prom
 import urllib3.connection
 from ipaddress import ip_address
 
-from . import atomic_write, ensure_directory, jitter
+from . import atomic_write, ensure_directory, jitter, listdir
 from .stats import timed
 
 
@@ -50,6 +50,12 @@ class BadScheme(Rejected):
 
 class WrongContent(Rejected):
 	"""Response was not a video or image"""
+
+
+def check_for_media(output_dir, url):
+	"""Returns True if we have at least one version of content for the given url already."""
+	url_dir = get_url_dir(output_dir, url)
+	return any(filename.endswith(".metadata.json") for filename in listdir(url_dir))
 
 
 @timed()

--- a/common/common/media.py
+++ b/common/common/media.py
@@ -1,0 +1,235 @@
+import json
+import logging
+import os
+import re
+import socket
+import time
+import urllib.parse
+from base64 import b64encode
+from hashlib import sha256
+from uuid import uuid4
+
+import gevent
+import prometheus_client as prom
+import urllib3.connection
+from ipaddress import ip_address
+
+from . import atomic_write, ensure_directory, jitter
+from .stats import timed
+
+
+media_bytes_downloaded = prom.Counter(
+	"media_bytes_downloaded",
+	"Number of bytes of media files downloaded. Includes data downloaded then later rejected.",
+)
+
+media_bytes_saved = prom.Histogram(
+	"media_bytes_saved",
+	"Size in bytes of downloaded media that was successfully saved",
+	["content_type"],
+	buckets = [2**n for n in range(11, 27, 2)],
+)
+
+media_already_exists = prom.Counter(
+	"media_already_exists",
+	"Count of times we downloaded a file but it already existed",
+)
+
+
+class Rejected(Exception):
+	"""Indicates a non-retryable failure due to the url response violating our constraints"""
+
+class TooLarge(Rejected):
+	"""Response was too large"""
+
+class ForbiddenDestination(Rejected):
+	"""Hostname resolved to non-global IP"""
+
+class BadScheme(Rejected):
+	"""Bad url scheme"""
+
+class WrongContent(Rejected):
+	"""Response was not a video or image"""
+
+
+@timed()
+def download_media(
+	url,
+	output_dir,
+	max_size=128*2**20, # 128MiB
+	timeout=60,
+	content_types=("image", "video"),
+	max_redirects=5,
+	retries=3,
+	retry_interval=1,
+	chunk_size=64*1024, # 64KiB
+):
+	"""Make a GET request to a potentially malicious URL and download the content to file.
+	We check the following:
+	- That the host is a public IP
+	- That the response does not exceed given max size (default 128MB)
+	- That the content type is in the given list
+	  (the list may contain exact types like "image/png" or categories like "image")
+	- That the whole thing doesn't take more than a timeout
+	Redirects *will* be followed but the follow-up requests must obey the same rules
+	(and do not reset the timeout).
+
+	We save the file to OUTPUT_DIR/URL_HASH/FILE_HASH.EXT where EXT is gussed from content-type.
+	We save additional metadata including the url and content type to OUTPUT_DIR/URL_HASH/FILE_HASH.metadata.json
+
+	Raises on any rule violation or non-200 response.
+	"""
+	# Stores a list of urls redirected to, latest is current.
+	urls = [url]
+
+	with gevent.Timeout(timeout):
+		for redirect_number in range(max_redirects):
+			errors = []
+			for retry in range(retries):
+				if retry > 0:
+					gevent.sleep(jitter(retry_interval))
+
+				try:
+					resp = _request(urls[-1], max_size, content_types)
+
+					new_url = resp.get_redirect_location()
+					if new_url:
+						urls.append(new_url)
+						break # break from retry loop, continuing in the redirect loop
+
+					_save_response(output_dir, urls, resp, max_size, chunk_size)
+					return
+				except Rejected:
+					raise
+				except Exception as e:
+					errors.append(e)
+					# fall through to next retry loop
+			else:
+				# This block will be reached if range(retries) runs out but not via "break"
+				raise ExceptionGroup(f"All retries failed for url {urls[-1]}", errors)
+
+		raise Exception("Too many redirects")
+
+
+def hash_to_path(hash):
+	return b64encode(hash.digest(), b"-_").decode().rstrip("=")
+
+
+def get_url_dir(output_dir, url):
+	return os.path.join(output_dir, hash_to_path(sha256(url.encode())))
+
+
+def _save_response(output_dir, urls, resp, max_size, chunk_size):
+	url_dir = get_url_dir(output_dir, urls[0])
+	temp_path = os.path.join(url_dir, f".{uuid4()}.temp")
+	ensure_directory(temp_path)
+
+	content_type = resp.headers["content-type"]
+	# Content type may have form "TYPE ; PARAMS", strip params if present.
+	# Also normalize for whitespace and case.
+	content_type = content_type.split(";")[0].strip().lower()
+	# We attempt to convert content type to an extension by taking the second part
+	# and stripping anything past the first character not in [a-z0-9-].
+	# So eg. "image/png" -> "png", "image/svg+xml" -> "svg", "image/../../../etc/password" -> ""
+	ext = content_type.split("/")[-1]
+	ext = re.match(r"^[a-z0-9.-]*", ext).group(0)
+
+	try:
+		length = 0
+		hash = sha256()
+		with open(temp_path, "wb") as f:
+			while True:
+				chunk = resp.read(chunk_size)
+				if not chunk:
+					break
+				hash.update(chunk)
+				length += len(chunk)
+				media_bytes_downloaded.inc(len(chunk))
+				if length > max_size:
+					raise TooLarge(f"Read more than {length} bytes from url {urls[-1]}")
+				f.write(chunk)
+
+		filename = f"{hash_to_path(hash)}.{ext}"
+		filepath = os.path.join(url_dir, filename)
+		# This is vulnerable to a race where two things create the file at once,
+		# but that's fine since it will always have the same content. This is just an optimization
+		# to avoid replacing the file over and over (and for observability)
+		if os.path.exists(filepath):
+			logging.info(f"Discarding downloaded file for {urls[0]} as it already exists")
+			media_already_exists.inc()
+		else:
+			os.rename(temp_path, filepath)
+			logging.info(f"Downloaded file for {urls[0]}")
+			media_bytes_saved.labels(content_type).observe(length)
+	finally:
+		if os.path.exists(temp_path):
+			os.remove(temp_path)
+
+	metadata_path = os.path.join(url_dir, f"{hash_to_path(hash)}.metadata.json")
+	# Again, this is racy but we don't care about double-writes.
+	# Note it's entirely possible for the image to already exist but still write the metadata,
+	# this can happen if a previous attempt crashed midway.
+	if not os.path.exists(metadata_path):
+		metadata = {
+			"url": urls[0],
+			"filename": filename,
+			"redirects": urls[1:],
+			"content_type": resp.headers["content-type"],
+			"fetched_by": socket.gethostname(),
+			"fetch_time": time.time(),
+		}
+		atomic_write(metadata_path, json.dumps(metadata, indent=4))
+
+
+def _request(url, max_size, content_types):
+	"""Do the actual request and return a vetted response object, which is either the content
+	(status 200) or a redirect.
+	Raises Rejected if content fails checks, anything else should be considered retryable."""
+	parsed = urllib.parse.urlparse(url)
+	hostname = parsed.hostname
+	port = parsed.port
+
+	ip = socket.gethostbyname(hostname)
+	if not ip_address(ip).is_global:
+		raise ForbiddenDestination(f"Non-global IP {ip} for url {url}")
+
+	# In order to provide the host/ip to connect to seperately from the URL,
+	# we need to drop to a fairly low-level interface.
+	if parsed.scheme == "http":
+		conn = urllib3.connection.HTTPConnection(ip, port or 80)
+	elif parsed.scheme == "https":
+		conn = urllib3.connection.HTTPSConnection(
+			ip, port or 443,
+			assert_hostname = hostname,
+			server_hostname = hostname,
+		)
+	else:
+		raise BadScheme(f"Bad scheme {parsed.scheme!r} for url {url}")
+
+	conn.request("GET", url, preload_content=False)
+	resp = conn.getresponse()
+
+	# Redirects do not require further checks
+	if resp.get_redirect_location():
+		return resp
+
+	if resp.status != 200:
+		raise Exception(f"Url returned {resp.status} response: {url}")
+
+	content_type = resp.getheader("content-type")
+	if content_type is None:
+		raise Exception(f"No content-type given for url {url}")
+	if not any(content_type.startswith(target) for target in content_types):
+		raise WrongContent(f"Disallowed content-type {content_type} for url {url}")
+
+	# If length is known but too large, reject early
+	length = resp.getheader("content-length")
+	if length is not None:
+		try:
+			length = int(length)
+		except ValueError:
+			raise Exception(f"Invalid content length {length!r} for url {url}")
+		if length > max_size:
+			raise TooLarge(f"Content length {length} is too large for url {url}")
+
+	return resp

--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -220,6 +220,8 @@
     token_path: "./chat_token.txt",
     // Whether to enable backfilling of chat archives to this node (if backfiller enabled)
     backfill: true,
+    // Whether to enable downloading of media (images, videos, etc) that is posted in chat.
+    download_media: true,
     // Channels to watch. Defaults to "all twitch channels in $.channels" but you can add extras.
     channels: [
       std.split(c, '!')[0]
@@ -614,7 +616,11 @@
     [if $.enabled.chat_archiver then "chat_archiver"]: {
       image: $.get_image("chat_archiver"),
       restart: "always",
-      command: [$.chat_archiver.user, "/token"] + $.chat_archiver.channels + ["--name", $.localhost],
+      command:
+        [$.chat_archiver.user, "/token"]
+        + $.chat_archiver.channels
+        + ["--name", $.localhost]
+        + (if $.chat_archiver.download_media then ["--download-media"] else []),
       volumes: ["%s:/mnt" % $.segments_path, "%s:/token" % $.chat_archiver.token_path],
       [if "chat_archiver" in $.ports then "ports"]: ["%s:8008" % $.ports.chat_archiver],
       environment: $.env,

--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -180,6 +180,11 @@
   // Extra directories (besides segments) to backfill
   backfill_dirs:: ["emotes"],
 
+  // Enable saving of media (images and videos - this can be large) and backfilling
+  // them from other nodes.
+  download_media:: false,
+  backfill_media:: $.download_media,
+
   // The spreadsheet id and worksheet names for sheet sync to act on
   // Set to null to disable syncing from sheets.
   sheet_id:: "your_id_here",
@@ -221,7 +226,7 @@
     // Whether to enable backfilling of chat archives to this node (if backfiller enabled)
     backfill: true,
     // Whether to enable downloading of media (images, videos, etc) that is posted in chat.
-    download_media: true,
+    download_media: $.download_media,
     // Channels to watch. Defaults to "all twitch channels in $.channels" but you can add extras.
     channels: [
       std.split(c, '!')[0]
@@ -367,7 +372,10 @@
       [
         "--base-dir", "/mnt",
         "--qualities", std.join(",", $.qualities + (if $.chat_archiver.backfill then ["chat"] else [])),
-        "--extras", std.join(",", $.backfill_dirs),
+        "--extras", std.join(",",
+          $.backfill_dirs
+          + (if $.backfill_media then ["media"] else [])
+        ),
         "--static-nodes", std.join(",", $.peers),
         "--backdoor-port", std.toString($.backdoor_port),
         "--node-database", $.db_connect,


### PR DESCRIPTION
Most of the logic here comes down to three thorny issues:
- How to identify links in chat
- Safely fetching from potentially-malicious URLs
- How to store that in the filesystem

We store things in such a way that it works with backfiller, so you can copy any data you miss
from other instances.

The purpose of all this is to provide an archive of images etc linked in chat *as they were at the time*, as links can rot quickly.
Special care is taken to re-check the content each time it's linked in case it returns a different result.

This may end up incurring a lot of disk usage. The expectation is that we'll only enable this for the main nodes.

Closes #403 