### PR TITLE
Thumbnail Template Management

### DIFF
--- a/common/common/images.py
+++ b/common/common/images.py
@@ -1,32 +1,20 @@
 
-import json
-import os
 import sys
 from io import BytesIO
 
 from PIL import Image
 
+
 """
-A template is two files:
-	NAME.png
-	NAME.json
-The image is the template image itself.
-The JSON file contains the following:
-	{
-		crop: BOX,
-		location: BOX,
-	}
-where BOX is a 4-tuple [left x, top y, right x, bottom y] describing a rectangle in image coordinates.
+A thumbnail template consists of a byte stream representation of a PNG template image along with two 4-tuples [left x, top y, right x, bottom y] describing the crop and location of the frame. 
 
 To create a thumbnail, the input frame is first cropped to the bounds of the "crop" box,
 then resized to the size of the "location" box, then pasted underneath the template image at that
 location within the template image.
 
-For example, a JSON file of:
-	{
-		"crop": [50, 100, 1870, 980],
-		"location": [320, 180, 1600, 900]
-	}
+For example
+crop = (50, 100, 1870, 980)
+location = (320, 180, 1600, 900)
 would crop the input frame from (50, 100) to (1870, 980), resize it to 720x1280,
 and place it at (320, 180).
 
@@ -34,18 +22,13 @@ If the original frame and the template differ in size, the frame is first resize
 This allows you to work with a consistent coordinate system regardless of the input frame size.
 """
 
-def compose_thumbnail_template(base_dir, template_name, frame_data):
-	template_path = os.path.join(base_dir, "thumbnail_templates", f"{template_name}.png")
-	info_path = os.path.join(base_dir, "thumbnail_templates", f"{template_name}.json")
+def compose_thumbnail_template(template_data, frame_data, crop, location):
 
-	template = Image.open(template_path)
 	# PIL can't load an image from a byte string directly, we have to pretend to be a file
+	template = Image.open(BytesIO(template_data))
 	frame = Image.open(BytesIO(frame_data))
 
-	with open(info_path) as f:
-		info = json.load(f)
-	crop = info['crop']
-	loc_left, loc_top, loc_right, loc_bottom = info['location']
+	loc_left, loc_top, loc_right, loc_bottom = location
 	location = loc_left, loc_top
 	location_size = loc_right - loc_left, loc_bottom - loc_top
 
@@ -72,14 +55,15 @@ def compose_thumbnail_template(base_dir, template_name, frame_data):
 	buf.seek(0)
 	return buf.read()
 
-
-def cli(template_name, image, base_dir="."):
-	with open(image, "rb") as f:
-		image = f.read()
-	thumbnail = compose_thumbnail_template(base_dir, template_name, image)
+def cli(template, frame, crop, location):
+	with open(template, "rb") as f:
+		template = f.read()
+	with open(frame, "rb") as f:
+		frame = f.read()
+	thumbnail = compose_thumbnail_template(template, frame, crop, location)
 	sys.stdout.buffer.write(thumbnail)
 
 
 if __name__ == '__main__':
 	import argh
-	argh.dispatch_command(cli)
+	argh.dispatch_command(cli)		

--- a/cutter/cutter/main.py
+++ b/cutter/cutter/main.py
@@ -18,7 +18,7 @@ from psycopg2 import sql
 import common
 from common.database import DBManager, query, get_column_placeholder
 from common.segments import get_best_segments, archive_cut_segments, fast_cut_segments, full_cut_segments, smart_cut_segments, extract_frame, ContainsHoles, get_best_segments_for_frame
-from common.images import compose_thumbnail_template
+from common.images import compose_thumbnail_template, get_template
 from common.stats import timed
 
 from .upload_backends import Youtube, Local, LocalArchive, UploadError
@@ -83,25 +83,6 @@ CutJob = namedtuple('CutJob', [
 	"thumbnail_segments",
 	# params which map directly from DB columns
 ] + CUT_JOB_PARAMS)
-
-def get_template(dbmanager, name, crop, location):
-	"""Fetch the thumbnail template and any missing parameters from the database"""
-	with dbmanager.get_conn() as conn:
-		query = """
-			SELECT image, crop, location FROM templates WHERE name = %s
-		"""
-		results = database.query(conn, query, name)
-		row = results.fetchone()
-		if row is None:
-			raise ValueError('Template {} not found'.format(name))
-		row = row._asdict()
-		if not crop:
-			crop = row['crop']
-		if not location:
-			location = row['location']
-
-		return row['image'], crop, location
-
 
 def get_duration(job):
 	"""Get total video duration of a job, in seconds"""

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -89,8 +89,14 @@ CREATE TABLE events (
 		OR thumbnail_mode = 'NONE'
 		OR thumbnail_last_written IS NOT NULL
 	),
-	thumbnail_crop INTEGER[], -- left, upper, right, and lower pixel coordinates to crop the selected frame
-	thumbnail_location INTEGER[], -- left, top, right, bottom pixel coordinates to position the cropped frame
+	thumbnail_crop INTEGER[] CHECK (
+		cardinality(thumbnail_crop) = 4
+		OR thumbnail_crop IS NULL
+	), -- left, upper, right, and lower pixel coordinates to crop the selected frame
+	thumbnail_location INTEGER[] CHECK (
+		cardinality(thumbnail_crop) = 4
+		OR thumbnail_crop IS NULL
+	), -- left, top, right, bottom pixel coordinates to position the cropped frame
 	
 	state event_state NOT NULL DEFAULT 'UNEDITED',
 	uploader TEXT CHECK (state IN ('UNEDITED', 'EDITED', 'DONE') OR uploader IS NOT NULL),
@@ -185,6 +191,8 @@ CREATE TABLE templates (
 	image BYTEA NOT NULL,
 	description TEXT NOT NULL DEFAULT '',
 	attribution TEXT NOT NULL DEFAULT '',
-	crop INTEGER[] NOT NULL,
-	location INTEGER[] NOT NULL 
+	crop INTEGER[] NOT NULL CHECK (
+		cardinality(thumbnail_crop) = 4),
+	location INTEGER[] NOT NULL CHECK (
+		cardinality(thumbnail_crop) = 4), 
 );

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -89,6 +89,8 @@ CREATE TABLE events (
 		OR thumbnail_mode = 'NONE'
 		OR thumbnail_last_written IS NOT NULL
 	),
+	thumbnail_crop INTEGER[], -- left, upper, right, and lower pixel coordinates to crop the selected frame
+	thumbnail_location INTEGER[], -- left, top, right, bottom pixel coordinates to position the cropped frame
 	
 	state event_state NOT NULL DEFAULT 'UNEDITED',
 	uploader TEXT CHECK (state IN ('UNEDITED', 'EDITED', 'DONE') OR uploader IS NOT NULL),
@@ -172,4 +174,17 @@ CREATE TABLE bus_data (
 	clock INTEGER,
 	timeofday TEXT,
 	PRIMARY KEY (channel, timestamp, segment)
+);
+
+-- This table stores video thumbnail templates and their associated metadata
+-- attribution: any attribution to be auto included in the video description. If empty, do not add an attribution
+-- crop: left, upper, right, and lower pixel coordinates to crop the selected frame
+-- location: left, top, right, bottom pixel coordinates to position the cropped frame
+CREATE TABLE templates (
+	name TEXT PRIMARY KEY,
+	image BYTEA NOT NULL,
+	description TEXT NOT NULL DEFAULT '',
+	attribution TEXT NOT NULL DEFAULT '',
+	crop INTEGER[] NOT NULL,
+	location INTEGER[] NOT NULL 
 );

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -122,9 +122,11 @@ CREATE TABLE nodes (
 	backfill_from BOOLEAN NOT NULL DEFAULT TRUE
 );
 
-CREATE TABLE editors (
+CREATE TABLE roles (
 	email TEXT PRIMARY KEY,
-	name TEXT NOT NULL
+	name TEXT NOT NULL,
+	editor BOOLEAN NOT NULL DEFAULT FALSE,
+	artist BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 -- A slight misnomer, this is all rows of the tags sheet.

--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -270,9 +270,9 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 		});
 
 	const thumbnailTemplateSelection = document.getElementById("video-info-thumbnail-template");
-	const thumbnailTemplatesListResponse = await fetch("/thumbnail-templates");
+	const thumbnailTemplatesListResponse = await fetch("/thrimshim/templates");
 	if (thumbnailTemplatesListResponse.ok) {
-		const thumbnailTemplatesList = await thumbnailTemplatesListResponse.json();
+		const thumbnailTemplatesList = (await thumbnailTemplatesListResponse.json()).map(t => t.name);
 		thumbnailTemplatesList.sort();
 		for (const templateName of thumbnailTemplatesList) {
 			const templateOption = document.createElement("option");


### PR DESCRIPTION
Rather than store thumbnail templates as files that have to manually copied to the edit nodes, store the thumbnails and associated metadata in the database (#358). Additionally, the crop and location thumbnail parameters can be overridden (#377) and a one-off template can be combined with a video frame to produce a custom thumbnail (#366). 

This is a work in progress and has not been tested (although it does build).