### PR TITLE
thrimletrimmer: Support one-off overlays for thumbnails

### DIFF
--- a/restreamer/restreamer/main.py
+++ b/restreamer/restreamer/main.py
@@ -520,7 +520,7 @@ def get_thumbnail_uploaded_template(channel, quality):
 		location: Required. Left, top, right, bottom pixel coordinates to position the cropped frame.
 			Should be a comma-seperated list of numbers.
 	"""	
-	template = request.body
+	template = request.data
 	return get_thumbnail(channel, quality, request.args['timestamp'], template, request.args['crop'], request.args['location'])
 
 

--- a/thrimbletrimmer/edit.html
+++ b/thrimbletrimmer/edit.html
@@ -231,6 +231,7 @@
 							<option value="NONE">No custom thumbnail</option>
 							<option value="BARE">Use video frame</option>
 							<option value="TEMPLATE" selected>Use video frame in image template</option>
+							<option value="ONEOFF">Use video frame with a custom one-off overlay</option>
 							<option value="CUSTOM">Use a custom thumbnail image</option>
 						</select>
 					</div>


### PR DESCRIPTION
By picking the "one-off overlay" option for a thumbnail, you swap
specifying a template name for being able to upload a one-off template that
is then combined with the requested frame.

The rendering is done by restreamer, and we do it explicitly whenever a)
Generate Thumbnail Preview is pressed b) The video is submitted

The rendered thumbnail is then included in the submission as a "custom"
thumbnail.

The default thumbnail template params (crop and location) do not change 
when this mode is selected, so they'll effectively be the default params of
the previously-selected template. In most cases this will be what you want
since almost all our templates share the same params, and custom one-offs
will too.