### PR TITLE
Match aspect ratio from frame to template or vice versa, or lock template to frame

### DIFF
--- a/thrimbletrimmer/edit.html
+++ b/thrimbletrimmer/edit.html
@@ -267,7 +267,7 @@
 								Update Source Images
 							</button>
 							<br/>
-							
+
 							<div class="video-info-thumbnail-advanced-crop-flex-wrapper">
 								<div class="video-info-thumbnail-advanced-crop-flex-item">
 									<img
@@ -285,7 +285,31 @@
 									<input type="text" class="video-info-thumbnail-position" id="video-info-thumbnail-crop-3" />
 									<br/>
 								</div>
-								
+
+								<div class="video-info-thumbnail-advanced-crop-flex-item hidden" id="video-info-thumbnail-aspect-ratio-controls">
+									<div class="video-info-thumbnail-advanced-crop-flex-column">
+										<div>
+											Aspect Ratio
+										</div>
+										<div>
+											<button id="video-info-thumbnail-aspect-ratio-match-right">
+												--Match-&gt;
+											</button>
+										</div>
+										<div>
+											<button id="video-info-thumbnail-aspect-ratio-match-left">
+												&lt;-Match--
+											</button>
+										</div>
+										<div>
+											<label>
+												<input type="checkbox" id="video-info-thumbnail-lock-aspect-ratio">
+												Lock
+											</label>
+										</div>
+									</div>
+								</div>
+
 								<div class="video-info-thumbnail-advanced-crop-flex-item">
 									<img
 										id="video-info-thumbnail-template-overlay-image"
@@ -303,6 +327,7 @@
 									<br/>
 								</div>
 							</div>
+
 						</details>
 					</div>
 					<div

--- a/thrimbletrimmer/styles/thrimbletrimmer.css
+++ b/thrimbletrimmer/styles/thrimbletrimmer.css
@@ -381,6 +381,18 @@ input.range-definition-chapter-marker-description {
 
 .video-info-thumbnail-advanced-crop-flex-wrapper {
 	display: flex;
+	align-items: center;
+}
+
+.video-info-thumbnail-advanced-crop-flex-column {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+}
+
+.video-info-thumbnail-advanced-crop-flex-column div {
+	margin: 0.5em;
 }
 
 .submission-response-error {


### PR DESCRIPTION
This patch updates the advanced thumbnail template cropping tool to allow the aspect ratio to be copied from the video frame to the template, from the template to the video frame, or to be locked at the video frame's current value. This allows editors to avoid accidental stretching of the video frame content.

Resolves #430 