### PR TITLE
Attach validation to the first chapter marker description field

### DIFF
--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -222,6 +222,9 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 		}
 	}
 
+	document.getElementById("range-definition-chapter-marker-first-description").addEventListener("input", (event) => {
+		validateChapterDescription(event.target);
+	});
 	document.getElementById("video-info-title").addEventListener("input", (event) => {
 		validateVideoTitle();
 		document.getElementById("video-info-title-abbreviated").innerText =


### PR DESCRIPTION
All of the other chapter markers get this event listener when they are created, but since this chapter marker already exists in the raw HTML, the event listener needs to be created when the page loads.

Resolves #429 