### PR TITLE
Don't check for active giveaways

### DIFF
--- a/zulip_bots/zulip_bots/pubbot.py
+++ b/zulip_bots/zulip_bots/pubbot.py
@@ -99,7 +99,7 @@ def main(conf_file, message_log_file, name=socket.gethostname()):
 				increase = None if total is None else msg["d"] - total
 				log["increase"] = increase
 				increase_str = "" if increase is None else " (+${:.2f})".format(msg["d"] - total)
-				giveaway = get_giveaway()
+				giveaway = None
 				entries_str = ""
 				if increase is not None and giveaway is not None:
 					amount = giveaway["amount"]


### PR DESCRIPTION
The old API is no more, so we can't check for active giveaway. Simply disable it for now.