### PR TITLE
Fixing pip in buscripe_api

### DIFF
--- a/buscribe_api/Dockerfile
+++ b/buscribe_api/Dockerfile
@@ -3,6 +3,9 @@ FROM alpine:3.14
 # also busybox-extras for telnet for easier use of backdoor
 RUN apk --update add py3-pip g++ python3-dev libffi-dev musl-dev postgresql-dev file make busybox-extras
 
+# should speed up installing python modules
+RUN pip install --upgrade pip wheel
+
 # Install gevent so that we don't need to re-install it when common changes
 RUN pip install gevent
 


### PR DESCRIPTION
A small change to speed up installing Python packages in `buscripe_api`

Installing wheels works fine in `buscripe` since it is using a Debian base image.

Partial fix for #450 