### PR TITLE
thrimbletrimmer: When no end time set, show and auto-refresh chat

### DIFF
--- a/thrimbletrimmer/scripts/common.js
+++ b/thrimbletrimmer/scripts/common.js
@@ -517,9 +517,12 @@ function triggerDownload(url, filename) {
 
 function sendChatLogLoadData() {
 	let startTime = getStartTime();
-	let endTime = getEndTime();
-	if (!startTime || !endTime) {
+	if (startTime === null) {
 		return;
+	}
+	let endTime = getEndTime();
+	if (endTime === null) {
+		endTime = DateTime.now().setZone("utc").plus({minutes: 1});
 	}
 	startTime = wubloaderTimeFromDateTime(startTime);
 	endTime = wubloaderTimeFromDateTime(endTime);


### PR DESCRIPTION
We request current time + 1 minute, and re-request every 10 seconds.

If I'm reading the code correctly, everything already correctly handles the chat being replaced
by a new fetch (as though we loaded a new video range).