### PR TITLE
thrimshim: use send_file to serve templates from database

### DIFF
--- a/thrimshim/thrimshim/main.py
+++ b/thrimshim/thrimshim/main.py
@@ -1,5 +1,6 @@
 import datetime
 from functools import wraps
+import io
 import json
 import logging
 import re

--- a/thrimshim/thrimshim/main.py
+++ b/thrimshim/thrimshim/main.py
@@ -628,7 +628,12 @@ def get_template(name):
 
 		image = row[0]
 		logging.info('Thumbnail image of {} fetched'.format(name))
-		return flask.Response(image, mimetype='image/png')
+		return flask.send_file(
+			io.BytesIO(image),
+			mimetype='image/png',
+			as_attachment=False,
+			download_name=f'{name}.png'
+		)
 
 
 @app.route('/thrimshim/template-metadata/<name>')


### PR DESCRIPTION
I don't claim to understand why this works, but this makes downloading the thumbnail templates (to preview on the thumbnail management page, or to select the "hole" in the advanced crop settings in the editor) way faster. Something to do with how flask is chunking the `memoryview` object to serve.

Applying this changed the timings to download "fiddling.png" from 818ms waiting and 6770ms receiving, to 777ms waiting and 14ms receiving.

Resolves #458