### PR TITLE
bus_analyzer time-of-day improvements

### DIFF
--- a/bus_analyzer/bus_analyzer/extract.py
+++ b/bus_analyzer/bus_analyzer/extract.py
@@ -315,8 +315,8 @@ def recognize_time_of_day(frame):
 	}
 	threshold = 20 # use stronger constraint once we have dusk, night and dawn footage
 	# these are for 720p; will need to multiple by 3/2 for 1080p
-	sky_pixel = frame.getpixel((1076, 128))
-	dash_pixel = frame.getpixel((630, 576))
+	sky_pixel = frame.getpixel((1614, 192))
+	dash_pixel = frame.getpixel((945, 864))
 	
 	MAX_DIST = 6**0.5 * 255
 	sky_distances = []

--- a/bus_analyzer/bus_analyzer/extract.py
+++ b/bus_analyzer/bus_analyzer/extract.py
@@ -314,7 +314,6 @@ def recognize_time_of_day(frame):
 		'dawn': (118, 0, 0), # estimated from previous years
 	}
 	threshold = 20 # use stronger constraint once we have dusk, night and dawn footage
-	# these are for 720p; will need to multiple by 3/2 for 1080p
 	sky_pixel = frame.getpixel((1614, 192))
 	dash_pixel = frame.getpixel((945, 864))
 	

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -167,7 +167,7 @@ CREATE TABLE playlists (
 -- be determined.
 -- The odometer column is in miles. The game shows the odometer to the 1/10th mile precision.
 -- The clock is in minutes since 00:00, in 12h time.
--- The time of day is one of "day", "dusk", "night", or "dawn"
+-- The time of day is one of "day", "dusk", "night", "dawn" or "score"
 -- The segment may be NULL, which indicates a manually-inserted value.
 -- The primary key serves two purposes:
 --   It provides an index on channel, followed by a range index on timestamp


### PR DESCRIPTION
Bus_analyzer now uses both a sky pixel and a dashboard pixel to determine time-of-day. The second pixel is required since the colour of the sky at night (black) is also the colour of a lot of loading screens. The bus_analyzer can now also determine when the game is in the score screen.

I have updated the pixel coordinates and pixel colours to the 720p version of this years stream. Changing the coordinates to 1080p is a simple matter of multiplication and the colours are almost the same at either resolution.