### PR TITLE
Set up multiplatform builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           - zulip_bots
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
           # By default, for PR builds, Actions will check out a merge commit between the actual
@@ -51,8 +51,14 @@ jobs:
           # This option makes it actually check out the PR's commit instead.
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Install QEMU
+        # qemu-user-static is used by buildah to do multiplatform builds
+        run: |
+          sudo apt update
+          sudo apt install -y qemu-user-static
+
       - name: Log into ghcr.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -62,8 +68,9 @@ jobs:
         # always push
         # if not a pull request and a push to master, also push "latest" tag
         # try to cache from previous build and then build component using build script
+        # set the multiarch flag so we also build arm64 images and not just amd64
         run: |
-          export PUSH=true CACHE=true
+          export PUSH=true CACHE=true MULTIPLATFORM=true
           # Only push latest when pushing to master
           if [ "$GITHUB_EVENT_NAME" != "pull_request" ] && [ "$GITHUB_REF" == "refs/heads/master" ]; then export PUSH=latest; fi
           # PRs from forked repositories can't have package write permissions, so use cache in readonly mode in those cases.


### PR DESCRIPTION
With QEMU we should be able to do multiplatform builds in Github Actions. Gonna see about setting that up.