### PR TITLE
thrimshim: Fix performance issue with getting template png

### DIFF
--- a/thrimshim/thrimshim/main.py
+++ b/thrimshim/thrimshim/main.py
@@ -765,7 +765,7 @@ def get_thumbnail(ident):
 
 		if event['thumbnail_mode'] != 'NONE' and event['thumbnail_image']:
 			logging.info('Thumbnail for event {} fetched'.format(ident))
-			return flask.Response(event['thumbnail_image'], mimetype='image/png')
+			return flask.Response(bytes(event['thumbnail_image']), mimetype='image/png')
 		else:
 			return '', 404
 			

--- a/thrimshim/thrimshim/main.py
+++ b/thrimshim/thrimshim/main.py
@@ -628,7 +628,7 @@ def get_template(name):
 
 		image = row[0]
 		logging.info('Thumbnail image of {} fetched'.format(name))
-		return flask.Response(image, mimetype='image/png')
+		return flask.Response(bytes(image), mimetype='image/png')
 
 
 @app.route('/thrimshim/template-metadata/<name>')


### PR DESCRIPTION
Bytes returned from the database are a "memoryview" and not a bytes object.
These mostly behave the same, but one difference is that Flask recognizes
a bytes object as something it can send as-is, whereas a memoryview ends up using
its generic "iterable" processing. This results in sending every individual byte of the result
as a single part of a HTTP chunked encoding response, adding 5 bytes and a syscall to every byte returned.

The solution is to explicitly convert it to bytes before returning.