### PR TITLE
pubbot: Get channel ids from config and handle prizes in the new website

### DIFF
--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -342,6 +342,10 @@
   pubbot:: {
     zulip_email: "blog-bot@chat.videostrike.team",
     zulip_api_key: "",
+    # The id for this year's total
+    total_id: "total:RZZQRDQNLNLW",
+    # The ids of any prizes to watch
+    prize_ids: [],
   },
 
   // template for donation data urls


### PR DESCRIPTION
Expects a hard-coded list of prize ids. We could in theory find open prize ids by parsing the html of the silent auctions page
but I'd rather not do that if we don't have to.

No longer displays the prize title in Zulip for the same reason, it just shows the id and links to it.