### PR TITLE
Thrimbletrimmer: Prevent arrow keys on the crop images from moving the play head

### DIFF
--- a/thrimbletrimmer/scripts/keyboard-shortcuts.js
+++ b/thrimbletrimmer/scripts/keyboard-shortcuts.js
@@ -144,6 +144,10 @@ document.addEventListener("keydown", (event) => {
 		return;
 	}
 
+	if (event.target.classList.contains("jcrop-widget") && (event.key === "ArrowLeft" || event.key === "ArrowRight")) {
+		return;
+	}
+
 	const videoElement = document.getElementById("video");
 	switch (event.key) {
 		case "ArrowLeft":


### PR DESCRIPTION
Resolves #486 