### PR TITLE
Thrimbletrimmer: Default video title to blank

### DIFF
--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -655,7 +655,9 @@ async function initializeVideoInfo() {
 	titlePrefixElem.innerText = videoInfo.title_prefix;
 
 	const titleElem = document.getElementById("video-info-title");
-	if (videoInfo.video_title) {
+	if (videoInfo.video_title !== null) {
+		// If a video titles was saved (even if it is blank), use that. Titles
+		// can't currently be blank, but we may be loosening validation for drafts.
 		titleElem.value = videoInfo.video_title;
 	} else {
 		// If a video title hasn't been set yet, leave it blank.
@@ -669,7 +671,8 @@ async function initializeVideoInfo() {
 		videoInfo.title_prefix + titleElem.value;
 
 	const descriptionElem = document.getElementById("video-info-description");
-	if (videoInfo.video_description) {
+	if (videoInfo.video_description !== null) {
+		// If a video description was saved (even if it is blank), use that.
 		descriptionElem.value = videoInfo.video_description;
 	} else {
 		// If a video description hasn't been set yet, use the descripton from the row.

--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -658,7 +658,11 @@ async function initializeVideoInfo() {
 	if (videoInfo.video_title) {
 		titleElem.value = videoInfo.video_title;
 	} else {
-		titleElem.value = videoInfo.description;
+		// If a video title hasn't been set yet, leave it blank.
+		// Exception: RDPs always use the standard title.
+		if (videoInfo.tags.includes("RDP")) {
+			titleElem.value = videoInfo.description;	
+		}
 	}
 	validateVideoTitle();
 	document.getElementById("video-info-title-abbreviated").innerText =
@@ -668,7 +672,11 @@ async function initializeVideoInfo() {
 	if (videoInfo.video_description) {
 		descriptionElem.value = videoInfo.video_description;
 	} else {
-		descriptionElem.value = videoInfo.description;
+		// If a video description hasn't been set yet, use the descripton from the row.
+		// Exception: RDPs start blank because the row is used for the title.
+		if (!videoInfo.tags.includes("RDP")) {
+			descriptionElem.value = videoInfo.description;
+		}
 	}
 	validateVideoDescription();
 


### PR DESCRIPTION
To encourage editors to write their own.

This patch simply uses the RDP tag to decide whether to use the row description as a default for the video title, or for the video description. This will probably be changed by #479 down the line, but that's lower priority and more complex, so this is a good starting point.

Resolves #504