### PR TITLE
Temporary debugging: Write out last 10 media playlists after fetching each segment

### DIFF
--- a/downloader/downloader/providers.py
+++ b/downloader/downloader/providers.py
@@ -29,7 +29,8 @@ class Provider:
 			session = InstrumentedSession()
 		resp = session.get(uri, metric_name='get_media_playlist')
 		resp.raise_for_status()
-		return hls_playlist.load(resp.text, base_uri=resp.url)
+		playlist = resp.text
+		return playlist, hls_playlist.load(playlist, base_uri=resp.url)
 
 
 class URLProvider(Provider):


### PR DESCRIPTION
This is some very old code that I've resurrected since we need it again. The PR is just so GHA builds images.

I'll clean this up into something we can keep merged but turned off later.