### PR TITLE
Add missing comma to config

### DIFF
--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -331,7 +331,7 @@
       access_token: "",
     },
     [if $.download_toot_media then "media_dir"]: "/mnt/media",
-    output_path: "/mnt/tootbot.json"
+    output_path: "/mnt/tootbot.json",
     args:: [],
   },
 


### PR DESCRIPTION
Without the comma, this is a syntax error that prevents building Wubloader.