### PR TITLE
thrimbletrimmer: hacky way to avoid loading large videos

### DIFF
--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -672,7 +672,9 @@ async function initializeVideoInfo() {
 	document.getElementById("stream-time-setting-end").value =
 		busTimeFromWubloaderTime(globalEndTimeString);
 
-	updateWaveform();
+	if (shouldLoadVideo()) {
+		updateWaveform();
+	}
 
 	const titlePrefixElem = document.getElementById("video-info-title-prefix");
 	titlePrefixElem.innerText = videoInfo.title_prefix;
@@ -812,7 +814,11 @@ async function initializeVideoInfo() {
 		advancedSubmissionContainer.classList.remove("hidden");
 	}
 
-	await loadVideoPlayerFromDefaultPlaylist();
+	if (shouldLoadVideo()) {
+		await loadVideoPlayerFromDefaultPlaylist();
+	} else {
+		addError("Not loading video as load_video=false was given. Most of the page will not work correctly.");
+	}
 
 	const videoElement = document.getElementById("video");
 	const handleInitialSetupForDuration = (_event) => {
@@ -2533,4 +2539,9 @@ function updateTemplateCropAspectRatio() {
 		videoFrameStage.setOptions({ aspectRatio: null });
 		templateStage.setOptions({ aspectRatio: null });
 	}
+}
+
+function shouldLoadVideo() {
+	const queryParams = new URLSearchParams(window.location.search);
+	return queryParams.get("load_video") !== "false";
 }


### PR DESCRIPTION
Partially implements #382, by adding a query param `load_video=false` which makes the
main video not load. This is only enabled explicitly because this leaves the UI in a quite broken state.
You cannot submit changes, see time ranges or transitions, or create thumbnails.

About all you CAN do is use the manual link and reset row buttons.
This suffices for the primary use-case, which is setting the manual link for Supercuts
that span several days.

This leaves the option in the future to do more without the video loaded,
such as submitting edits to title/description.