### PR TITLE
downloader: Add max concurrency for segment getters

### DIFF
--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -600,6 +600,8 @@ class SegmentGetter(object):
 	def exists(self):
 		"""Look for an existing, full (non-partial, non-suspect) copy of this segment. Return bool."""
 		dirname = os.path.dirname(self.prefix)
+		file_prefix = os.path.basename(self.prefix)
+		full_prefix = "{}-full".format(file_prefix)
 		try:
 			candidates = os.listdir(dirname)
 		except OSError as e:
@@ -607,7 +609,6 @@ class SegmentGetter(object):
 			if e.errno != errno.ENOENT:
 				raise
 			return False
-		full_prefix = "{}-full".format(self.prefix)
 		return any(
 			candidate.startswith(full_prefix)
 				# There's almost no way a matching tombstone could already exist, but just in case

--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -141,7 +141,7 @@ class StreamsManager(object):
 
 	FETCH_TIMEOUTS = 5, 30
 
-	def __init__(self, provider, channel, base_dir, qualities, important=False, history_size=0):
+	def __init__(self, provider, channel, base_dir, qualities, important=False, history_size=0, max_stream_segment_getters=64):
 		self.provider = provider
 		self.channel = channel
 		self.logger = logging.getLogger("StreamsManager({})".format(channel))
@@ -153,6 +153,7 @@ class StreamsManager(object):
 		self.stopping = gevent.event.Event() # set to tell main loop to stop
 		self.important = important
 		self.history_size = history_size
+		self.max_stream_segment_getters = max_stream_segment_getters
 		self.master_playlist_log_level = logging.INFO if important else logging.DEBUG
 		if self.important:
 			self.FETCH_MIN_INTERVAL = self.IMPORTANT_FETCH_MIN_INTERVAL
@@ -223,7 +224,7 @@ class StreamsManager(object):
 			self.logger.info("Ignoring worker start as we are stopping")
 			return
 		url_time, url = self.latest_urls[quality]
-		worker = StreamWorker(self, quality, url, url_time, self.history_size)
+		worker = StreamWorker(self, quality, url, url_time, self.history_size, self.max_stream_segment_getters)
 		self.stream_workers[quality].append(worker)
 		gevent.spawn(worker.run)
 
@@ -315,7 +316,7 @@ class StreamWorker(object):
 	# See https://github.com/dbvideostriketeam/wubloader/issues/539
 	MAX_SEGMENT_TIME_SKEW = 0.01
 
-	def __init__(self, manager, quality, url, url_time, history_size):
+	def __init__(self, manager, quality, url, url_time, history_size, max_segment_getters):
 		self.manager = manager
 		self.logger = manager.logger.getChild("StreamWorker({})@{:x}".format(quality, id(self)))
 		self.quality = quality
@@ -340,6 +341,9 @@ class StreamWorker(object):
 		# If enabled, playlist history is saved after each segment fetch,
 		# showing the last N playlist fetches up until the one that resulted in that fetch.
 		self.history_size = history_size
+		# Limits number of concurrently running segment getters.
+		# This is needed for providers that give you all historical segments at once.
+		self.getter_pool = gevent.pool.Pool(max_segment_getters)
 
 	def __repr__(self):
 		return "<{} at 0x{:x} for stream {!r}>".format(type(self).__name__, id(self), self.quality)
@@ -452,7 +456,8 @@ class StreamWorker(object):
 						self.map_cache,
 						history,
 					)
-					gevent.spawn(self.getters[segment.uri].run)
+					# Note this will block if we hit max segment getters
+					self.getter_pool.spawn(self.getters[segment.uri].run)
 				if date is not None:
 					date += datetime.timedelta(seconds=segment.duration)
 				prev_segment = segment
@@ -713,7 +718,7 @@ def parse_channel(channel):
 	"This affects retry interval, error reporting and monitoring. "
 	"Non-twitch URLs can also be given with the form CHANNEL[!]:TYPE:URL"
 )
-def main(channels, base_dir=".", qualities="source", metrics_port=8001, backdoor_port=0, twitch_auth_file=None, playlist_debug=0):
+def main(channels, base_dir=".", qualities="source", metrics_port=8001, backdoor_port=0, twitch_auth_file=None, playlist_debug=0, max_stream_segment_getters=64):
 	qualities = qualities.split(",") if qualities else []
 
 	twitch_auth_token = None
@@ -734,7 +739,7 @@ def main(channels, base_dir=".", qualities="source", metrics_port=8001, backdoor
 			channel_qualities = ["source"]
 		else:
 			raise ValueError(f"Unknown type {type!r}")
-		manager = StreamsManager(provider, channel, base_dir, channel_qualities, important=important, history_size=playlist_debug)
+		manager = StreamsManager(provider, channel, base_dir, channel_qualities, important=important, history_size=playlist_debug, max_stream_segment_getters=max_stream_segment_getters)
 		managers.append(manager)
 
 	def stop():

--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -141,7 +141,7 @@ class StreamsManager(object):
 
 	FETCH_TIMEOUTS = 5, 30
 
-	def __init__(self, provider, channel, base_dir, qualities, important=False, history_size=0, max_stream_segment_getters=64):
+	def __init__(self, provider, channel, base_dir, qualities, important=False, history_size=0, max_stream_segment_getters=None):
 		self.provider = provider
 		self.channel = channel
 		self.logger = logging.getLogger("StreamsManager({})".format(channel))
@@ -153,6 +153,8 @@ class StreamsManager(object):
 		self.stopping = gevent.event.Event() # set to tell main loop to stop
 		self.important = important
 		self.history_size = history_size
+		if max_stream_segment_getters is None:
+			max_stream_segment_getters = provider.MAX_SEGMENT_GETTERS
 		self.max_stream_segment_getters = max_stream_segment_getters
 		self.master_playlist_log_level = logging.INFO if important else logging.DEBUG
 		if self.important:
@@ -718,7 +720,7 @@ def parse_channel(channel):
 	"This affects retry interval, error reporting and monitoring. "
 	"Non-twitch URLs can also be given with the form CHANNEL[!]:TYPE:URL"
 )
-def main(channels, base_dir=".", qualities="source", metrics_port=8001, backdoor_port=0, twitch_auth_file=None, playlist_debug=0, max_stream_segment_getters=64):
+def main(channels, base_dir=".", qualities="source", metrics_port=8001, backdoor_port=0, twitch_auth_file=None, playlist_debug=0):
 	qualities = qualities.split(",") if qualities else []
 
 	twitch_auth_token = None
@@ -739,7 +741,7 @@ def main(channels, base_dir=".", qualities="source", metrics_port=8001, backdoor
 			channel_qualities = ["source"]
 		else:
 			raise ValueError(f"Unknown type {type!r}")
-		manager = StreamsManager(provider, channel, base_dir, channel_qualities, important=important, history_size=playlist_debug, max_stream_segment_getters=max_stream_segment_getters)
+		manager = StreamsManager(provider, channel, base_dir, channel_qualities, important=important, history_size=playlist_debug)
 		managers.append(manager)
 
 	def stop():

--- a/downloader/downloader/providers.py
+++ b/downloader/downloader/providers.py
@@ -17,6 +17,9 @@ class Provider:
 	# However the default is an arbitrarily long period (ie. never).
 	MAX_WORKER_AGE = 30 * 24 * 60 * 60 # 30 days
 
+	# Max allowed concurrent segment fetches
+	MAX_SEGMENT_GETTERS = 64
+
 	def get_media_playlist_uris(self, qualities, session=None):
 		"""Fetches master playlist and returns {quality: media playlist URI} for each
 		requested quality."""
@@ -61,6 +64,9 @@ class YoutubeProvider(Provider):
 	"""
 	# Youtube links expire after 6h, so roll workers at 5h
 	MAX_WORKER_AGE = 5 * 60 * 60
+
+	# Youtube throws rate limit errors above this value
+	MAX_SEGMENT_GETTERS = 4
 
 	def __init__(self, youtube_url):
 		self.youtube_url = youtube_url


### PR DESCRIPTION
Some providers, such as youtube, provide the entire history of segment files.
If we start watching a stream that has already been running for hours, we try to fetch
several thousand segments at once, which causes timeouts at best and gets us blocked at worst.

The solution is a concurrency limit on how many segment getters are running.