### PR TITLE
Move database schema documentation inline into the schema file

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -151,56 +151,6 @@ uploaded. This allows us to detect if it has changed when modifying a video.
 We could query the current thumbnail from youtube's API, but this may be re-encoded or scaled
 and not have exactly the same content.
 
-#### Full schema
-
-The details below assume postgres, but nothing is signifigantly different in any SQL DB,
-except the use of arrays which would need to be split out into another table, but even that is
-a straightforward change.
-
-Note that most of the sheet input string types are `NOT NULL DEFAULT ''`, as when taking sheet inputs,
-there is no meaningful distinction between "unset" and "set to empty string".
-However, for other sheet inputs, a NULL is used to indicate unset / an unparsable value.
-
-Edit input values are initially NULL, but must not be NULL once the state is no longer `UNEDITED`.
-
-columns                    | type                                 | role        | description
--------------------------- | ----------------------------------   | :---------: | -----------
-`id`                       | `TEXT PRIMARY KEY`                   | sheet input | Generated and attached to rows in the sheet to uniquely identify them even in the face of added, deleted or moved rows.
-`sheet_name`               | `TEXT NOT NULL`                      | sheet input | The name of the worksheet that the row is on. This is used to tag videos, and can be used to narrow down the range to look for an id in for more efficient lookup (though we never do that right now).
-`event_start`, `event_end` | `TIMESTAMP`                          | sheet input | Start and end time of the event. Parsed from the sheet into timestamps or NULL. Used to set the editor time span, and displayed on the public sheet. The start time also determines what "day" the event lies on, for video tagging and other purposes.
-`category`                 | `TEXT NOT NULL DEFAULT ''`           | sheet input | The kind of event. By convention selected from a small list of categories, but stored as an arbitrary string because there's little to no benefit to using an enum here, it just makes our job harder when adding a new category. Used to tag videos, and for display on the public sheet.
-`description`              | `TEXT NOT NULL DEFAULT ''`           | sheet input | Event description. Provides the default title and description for editors, and displayed on the public sheet.
-`submitter_winner`         | `TEXT NOT NULL DEFAULT ''`           | sheet input | A column detailing challenge submitter, auction winner, or other "associated person" data. This shouldn't be relied on in any processing but should be displayed on the public sheet.
-`poster_moment`            | `BOOLEAN NOT NULL DEFAULT FALSE`     | sheet input | Whether or not the event was featured on the poster. Used for building the postermap and also displayed on the public sheet.
-`image_links`              | `TEXT[] NOT NULL`                    | sheet input | Any additional gif or image links associated with the event. Displayed on the public sheet.
-`notes`                    | `TEXT NOT NULL DEFAULT ''`           | sheet input | Private notes on this event, used eg. to leave messages or special instructions. Displayed to the editor during editing, but otherwise unused.
-`tags`                     | `TEXT[] NOT NULL`                    | sheet input | Custom tags to annotate this event's video with. Provides the default tags that the editor can then adjust.
-`allow_holes`              | `BOOLEAN NOT NULL DEFAULT FALSE`     | edit input  | If false, any missing segments encountered while cutting will cause the cut to fail. Setting this to true should be done by an operator to indicate that holes are expected in this range. It is also the operator's responsibility to ensure that all allowed cutters have all segments that they can get, since there is no guarentee that only the cutter with the least missing segments will get the cut job.
-`uploader_whitelist`       | `TEXT[]`                             | edit input  | List of uploaders which are allowed to cut this entry, or NULL to indicate no restriction. This is useful if you are allowing holes and the amount of missing data differs between nodes (this shouldn't happen - this would mean replication is also failing), or if an operator is investigating a problem with a specific node.
-`upload_location`          | `TEXT`                               | edit input  | The upload location to upload the cut video to. This is used by the cutter, and must match one of the cutter's configured upload locations. If it does not, the cutter will not claim the event.
-`public`                   | `BOOLEAN NOT NULL DEFAULT TRUE`      | edit input  | Whether the uploaded video should be public or not, if the upload location supports that distinction. For example, on youtube, non-public videos are "unlisted". It also controls whether the video will be added to playlists, only public videos are added to playlists.
-`video_ranges`             | `{start TIMESTAMP, end TIMESTAMP}[]` | edit input  | A non-zero number of start and end times, describing the ranges of video to cut. They will be cut back-to-back in the given order, with the transitions between as per `video_transitions`. If already set, used as the default range settings when editing.
-`video_transitions`        | `{type TEXT, duration DOUBLE PRECISION}[]`| edit input  | Defines how to transition between each range defined in `video_ranges`, and must be exactly the length of `video_ranges` minus 1. Each index in `video_transitions` defines the transition between the range with the same index in `video_ranges` and the next one. Transitions either specify a transition type as understood by `ffmpeg`'s `xfade` filter and a duration (amount of overlap), or can be NULL to indicate a hard cut.
-`video_title`              | `TEXT`                               | edit input  | The title of the video. If already set, used as the default title when editing instead of `description`.
-`video_description`        | `TEXT`                               | edit input  | The description field of the video. If already set, used as the default description when editing instead of `description`.
-`video_tags`               | `TEXT[]`                             | edit input  | Custom tags to annotate the video with. If already set, used as the default when editing instead of `tags`.
-`video_channel`            | `TEXT`                               | edit input  | The twitch channel to cut the video from. If already set, used as the default channel selection when editing, instead of a pre-configured editor default. While this will almost always be the default value, it's a useful thing to be able to change should the need arise.
-`video_quality`            | `TEXT NOT NULL DEFAULT 'source'`      | edit input  | The stream quality to cut the video from. Used as the default quality selection when editing. While this will almost always be the default value, it's a useful thing to be able to change should the need arise.
-`thumbnail_mode`           | `ENUM NOT NULL DEFAULT 'TEMPLATE'`    | edit input  | The thumbnail mode. See "Thumbnails" above.
-`thumbnail_time`           | `TIMESTAMP`                          | edit input  | The video time to grab a frame from for the thumbnail in BARE and TEMPLATE modes.
-`thumbnail_template`       | `TEXT`                               | edit input  | The template name to use for the thumbnail in TEMPLATE mode.
-`thumbnail_image`          | `BYTEA`                              | edit input  | In CUSTOM mode, the thumbnail image. In BARE and TEMPLATE modes, the generated thumbnail image, or NULL to indicate it should be generated when next needed.
-`state`                    | `ENUM NOT NULL DEFAULT 'UNEDITED'`   | state       | See "The state machine" above.
-`uploader`                 | `TEXT`                               | state       | The name of the cutter node performing the cut and upload. Set when transitioning from `EDITED` to `CLAIMED` and cleared on a retryable error. Left uncleared on non-retryable errors to provide information to the operator. Cleared on a re-edit if set.
-`error`                    | `TEXT`                               | state       | A human-readable error message, set if a non-retryable error occurs. Its presence indicates operator intervention is required. Cleared on a re-edit if set.
-`video_id`                 | `TEXT`                               | state       | An id that can be used to refer to the video to check if transcoding is complete. Often the video_link can be generated from this, but not nessecarily.
-`video_link`               | `TEXT`                               | output      | A link to the uploaded video. Only set when state is `TRANSCODING` or `DONE`.
-`editor`                   | `TEXT`                               | state       | Email address of the last editor; corresponds to an entry in the `editors` table. Only set when state is not `UNEDITED`.
-`edit_time`                | `TIMESTAMP`                          | state       | Time of the last edit. Only set when state is not `UNEDITED`.
-`upload_time`              | `TIMESTAMP`                          | state       | Time when video state is set to `DONE`. Only set when state is `DONE`.
-`last_modified`            | `TIMESTAMP`                          | state       | Time when video state was last set to `MODIFIED`, or NULL if it has never been. Only used for diagnostics.
-`thumbnail_last_written`   | `BYTEA`                              | state       | The SHA256 hash, in binary form, of the most recently uploaded thumbnail image.
-
 ### Audit Logging
 
 We are using [a third party audit trigger](https://wiki.postgresql.org/wiki/Audit_trigger_91plus)

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -20,9 +20,13 @@ CREATE TYPE video_transition as (
 );
 
 CREATE TYPE thumbnail_mode as ENUM (
+	-- Do not set a thumbnail
 	'NONE',
+	-- Set the thumbnail to a video frame
 	'BARE',
+	-- Set the thumbnail to a video frame rendered with a thumbnail template
 	'TEMPLATE',
+	-- Set the thumbnail to an uploaded image
 	'CUSTOM'
 );
 
@@ -39,71 +43,171 @@ CREATE TYPE end_time AS (
 	value TIMESTAMP
 );
 
+-- Each row on the sheet is an event.
 CREATE TABLE events (
+	-- id is generated and attached to rows in the sheet to uniquely identify them
+	-- even in the face of added, deleted or moved rows.
 	id TEXT PRIMARY KEY,
 
+	-- The following are "sheet inputs", taken from the sheet row.
+	-- Many of them are "NOT NULL DEFAULT ''", as in a spreadsheet there is no distinction
+	-- between "unset" and an empty string.
+
+	-- The name of the worksheet that the row is on. This is used to tag videos,
+	-- and for reverse sync.
 	sheet_name TEXT NOT NULL,
+	-- The start and end times written on the sheet, or NULL if no valid timestamp.
+	-- End time additionally stores whether it was originally written as "--" (same as timestamp) or explicitly.
+	-- Used to set editor time span, and displayed on the public sheet.
+	-- The start time also determines what "day" the event lies on, for video tagging and other purposes.
 	event_start TIMESTAMP,
 	event_end end_time DEFAULT ROW(false, NULL) CHECK (
+		-- dashed bool should be non-null
 		(event_end).dashed IS NOT NULL
+		-- if dashed is true, value should equal event_start
 		AND ((event_end).dashed != TRUE OR (event_end).value IS NOT DISTINCT FROM event_start)
 	),
+	-- The kind of event. By convention selected from a small list of categories,
+	-- but stored as an arbitrary string because there's little to no benefit to using an enum here,
+	-- it just makes our job harder when adding a new category.
+	-- Used to tag videos, and for display on the public sheet.
 	category TEXT NOT NULL DEFAULT '',
+	-- Event description. Provides the default description for editors, and displayed on the public sheet.
 	description TEXT NOT NULL DEFAULT '',
+	-- A column detailing challenge submitter, auction winner, or other "associated" data like quiz answers.
+	-- This shouldn't be relied on in any processing but should be displayed on the public sheet.
 	submitter_winner TEXT NOT NULL DEFAULT '',
+	-- Whether or not the event was featured on the poster.
+	-- Used for building the postermap and also displayed on the public sheet.
 	poster_moment BOOLEAN NOT NULL DEFAULT FALSE,
+	-- Any additional media or other URLs associated with the event.
+	-- May not be an image. Displayed on the public sheet.
 	image_links TEXT[] NOT NULL DEFAULT '{}', -- default empty array
+	-- Private notes on this event, used eg. to leave messages or special instructions.
+	-- Displayed to the editor during editing.
 	notes TEXT NOT NULL DEFAULT '',
+	-- Custom tags to annotate this event's video with. Provides the default tags that the editor can then adjust.
+	-- Also used to determine which playlists a video should be in, and by extension the default video thumbnail.
+	-- This list includes some extra tags in addition to what is on the sheet, like sheet name and category.
 	tags TEXT[] NOT NULL DEFAULT '{}', -- default empty array
 
+	-- The following are "edit inputs", set by the editor when submitting an edit or draft.
+	-- They are initially NULL, but most must be non-NULL once the video is in an edited state.
+	-- When loading the editor, if these were previously set, they are restored.
+	-- Otherwise defaults are loaded.
+
+	-- If false, any missing segments encountered while cutting will cause the cut to fail.
+	-- Setting this to true should be done to indicate that holes are expected in this range.
+	-- It is the user's responsibility to ensure that all allowed cutters have all segments that they can get,
+	-- since there is no guarentee that the cutter with the least missing segments will get the cut job.
 	allow_holes BOOLEAN NOT NULL DEFAULT FALSE,
+	-- List of uploaders which are allowed to cut this entry, or NULL to indicate no restriction.
+	-- This is useful if you are allowing holes and the amount of missing data differs between nodes
+	-- (this would only happen if replication is also failing), or testing with a specific node.
 	uploader_whitelist TEXT[],
+	-- The upload location to upload the cut video to. This is used by the cutter,
+	-- and must match one of the cutter's configured upload locations. If it does not, the cutter will not claim the event.
 	upload_location TEXT CHECK (state = 'UNEDITED' OR upload_location IS NOT NULL),
+	-- Whether the uploaded video should be public or not, if the upload location supports that distinction.
+	-- For youtube, non-public videos are "unlisted".
+	-- Non-public videos will not be added to playlists.
 	public BOOLEAN NOT NULL DEFAULT TRUE,
+
+	-- A non-zero number of start and end times, describing the ranges of video to cut.
+	-- They will be cut back-to-back in the given order, with the transitions between as per `video_transitions`.
 	video_ranges video_range[] CHECK (state IN ('UNEDITED', 'DONE') OR video_ranges IS NOT NULL),
+	-- Defines how to transition between each range defined in `video_ranges`,
+	-- and must be exactly the length of `video_ranges` - 1.
+	-- Each index in `video_transitions` defines the transition between the range with the same index in `video_ranges` and the next one.
+	-- Transitions either specify a transition type as understood by ffmpeg's "xfade" filter and a duration,
+	-- or can be NULL to indicate a hard cut.
 	video_transitions video_transition[] CHECK (state IN ('UNEDITED', 'DONE') OR video_transitions IS NOT NULL),
 	CHECK (
 		(video_ranges IS NULL AND video_transitions IS NULL)
 		OR CARDINALITY(video_ranges) = CARDINALITY(video_transitions) + 1
 	),
+	-- The title of the video
 	video_title TEXT CHECK (state IN ('UNEDITED', 'DONE') OR video_title IS NOT NULL),
+	-- The video description. Defaults to the sheet description.
 	video_description TEXT CHECK (state IN ('UNEDITED', 'DONE') OR video_description IS NOT NULL),
+	-- Tags to set on the video. Defaults to the sheet tags, plus a preset list.
 	video_tags TEXT[] CHECK (state IN ('UNEDITED', 'DONE') OR video_tags IS NOT NULL),
+	-- The twitch channel to cut the video from.
 	video_channel TEXT CHECK (state IN ('UNEDITED', 'DONE') OR video_channel IS NOT NULL),
+	-- The stream quality to cut the video from. You almost always want "source", but might need
+	-- something else for testing.
 	video_quality TEXT NOT NULL DEFAULT 'source',
 
+	-- The thumbnail mode, which determines which other thumbnail columns will be used.
+	-- Unused columns are NOT enforced to be NULL, so that if you switch modes then switch
+	-- back the old settings aren't lost.
 	thumbnail_mode thumbnail_mode NOT NULL DEFAULT 'TEMPLATE',
+	-- For BARE and TEMPLATE thumbnails, the video timestamp to take the source frame from.
 	thumbnail_time TIMESTAMP CHECK (
 		state = 'UNEDITED'
 		OR thumbnail_mode in ('NONE', 'CUSTOM')
 		OR thumbnail_time IS NOT NULL
 	),
+	-- For TEMPLATE thumbnails, the name of the template to use.
 	thumbnail_template TEXT CHECK (
 		state = 'UNEDITED'
 		OR thumbnail_mode != 'TEMPLATE'
 		OR thumbnail_template IS NOT NULL
 	),
+	-- For TEMPLATE thumbnails, the bounding box in the source frame to grab from.
+	thumbnail_crop box_coords CHECK (
+		state = 'UNEDITED'
+		OR thumbnail_mode != 'TEMPLATE'
+		OR thumbnail_crop IS NOT NULL
+	),
+	-- For TEMPLATE thumbnails, the bounding box in the template to paste into.
+	thumbnail_location box_coords CHECK (
+		state = 'UNEDITED'
+		OR thumbnail_mode != 'TEMPLATE'
+		OR thumbnail_location IS NOT NULL
+	),
+	-- For CUSTOM thumbnails, the thumbnail image to use.
+	-- For BARE and TEMPLATE thumbnails, a saved copy of the generated image, or NULL to indicate it needs to be regenerated.
+	-- This has two important effects:
+	--   We don't need to re-render (and worry about reproducibility) every time the video is modified to check if it changed
+	--   Changes in a template don't immediately apply retroactively to existing thumbnails
 	thumbnail_image BYTEA CHECK (
 		state = 'UNEDITED'
 		OR thumbnail_mode != 'CUSTOM'
 		OR thumbnail_image IS NOT NULL
 	),
+	-- SHA256 hash of the most recently uploaded thumbnail image.
+	-- Used to know if we need to update the thumbnail.
 	thumbnail_last_written BYTEA CHECK (
 		state != 'DONE'
 		OR thumbnail_mode = 'NONE'
 		OR thumbnail_last_written IS NOT NULL
 	),
-	thumbnail_crop box_coords, -- pixel coordinates to crop the selected frame
-	thumbnail_location box_coords, -- pixel coordinates to position the cropped frame
-	
+
+	-- The remaining fields are used for housekeeping, tracking state, and providing outputs to the sheet.
+
+	-- The state field governs the steps a row takes to be uploaded. See docs/DATABASE.md for details.
 	state event_state NOT NULL DEFAULT 'UNEDITED',
+	-- The name of the cutter node performing the cut and upload.
+	-- Set when transitioning from `EDITED` to `CLAIMED` and cleared on a retryable error.
+	-- Left uncleared on non-retryable errors to provide information. Cleared on a re-edit if set.
 	uploader TEXT CHECK (state IN ('UNEDITED', 'EDITED', 'DONE', 'MODIFIED') OR uploader IS NOT NULL),
+	-- A human-readable error message, set if a non-retryable error occurs.
+	-- Its presence indicates operator intervention is required. Cleared on a re-edit if set.
 	error TEXT,
+	-- An id that can be used to refer to the video to check if transcoding is complete.
+	-- For youtube, the video_link can be generated from this, but we don't rely on that.
 	video_id TEXT,
+	-- A link to the uploaded video. Set when state is `TRANSCODING` or `DONE`.
 	video_link TEXT CHECK ((NOT (state IN ('DONE', 'MODIFIED'))) OR video_link IS NOT NULL),
+	-- Email address of the last editor; corresponds to an entry in the roles table.
 	editor TEXT,
+	-- Time the last edit or draft or was submitted, only used for diagnostics.
 	edit_time TIMESTAMP CHECK (state = 'UNEDITED' OR editor IS NOT NULL),
+	-- Time when video state is set to DONE, only used for diagnostics.
 	upload_time TIMESTAMP CHECK ((NOT (state IN ('DONE', 'MODIFIED'))) OR upload_time IS NOT NULL),
+	-- Time when video state was last set to MODIFIED, or NULL if it has never been.
+	-- Only used for diagnostics.
 	last_modified TIMESTAMP CHECK (state != 'MODIFIED' OR last_modified IS NOT NULL)
 );
 
@@ -115,17 +219,25 @@ CREATE INDEX event_state ON events (state);
 -- and change it back if needed. More about accidents than security.
 SELECT audit.audit_table('events');
 
+-- What nodes are available to replicate from
 CREATE TABLE nodes (
+	-- Unique name, so nodes know not to replicate from themselves
 	name TEXT PRIMARY KEY,
+	-- Base URL for restreamer
 	url TEXT NOT NULL,
+	-- Only backfill from this node when this is true
 	backfill_from BOOLEAN NOT NULL DEFAULT TRUE
 );
 
+-- Table containing user emails and which permissions they should have.
 CREATE TABLE roles (
 	-- email should always be lowercase since that's how the auth function compares it
 	email TEXT PRIMARY KEY CHECK (email = lower(email)),
+	-- Name is just used for human readability
 	name TEXT NOT NULL,
+	-- Editors are allowed to submit edits to videos
 	editor BOOLEAN NOT NULL DEFAULT FALSE,
+	-- Artists are allowed to manage thumbnails
 	artist BOOLEAN NOT NULL DEFAULT FALSE
 );
 
@@ -137,17 +249,21 @@ CREATE TABLE playlists (
 	-- These are sheet inputs, and aren't used directly by anything (except reverse sync)
 	name TEXT NOT NULL DEFAULT '',
 	description TEXT NOT NULL DEFAULT '',
+	-- A list of tags, all of which a video must have to be included in this playlist.
 	-- When tags is NULL, it indicates tags have not been set and so the playlist should
 	-- match nothing. Conversely, when tags is empty, it indicates the playlist should match everything.
 	tags TEXT[],
+	-- Youtube playlist ID, if there is one.
 	playlist_id TEXT UNIQUE,
+	-- If true, videos in this playlist will point to the playlist in their description.
 	show_in_description BOOLEAN NOT NULL DEFAULT FALSE,
 	-- These event ids are references into the events table, but they aren't foreign keys
 	-- because we don't want invalid input to cause integrity errors.
 	-- It's totally safe for these to point to non-existent events, it just does nothing.
+	-- If they are valid, it changes the sort order of the playlist to put these videos first or last.
 	first_event_id TEXT,
 	last_event_id TEXT,
-	-- name of the thumbnail template to be applied by default to this tag
+	-- name of the thumbnail template to be applied by default to videos in this playlist.
 	default_template TEXT
 );
 


### PR DESCRIPTION
This is easier to maintain and easier to find.
Almost no functional change intended - we add slightly stronger constraints on thumbnail crop boxes.

Fixes https://github.com/dbvideostriketeam/wubloader/issues/442