### PR TITLE
backend: Manage chapter markers as a database column

### DIFF
--- a/cutter/cutter/main.py
+++ b/cutter/cutter/main.py
@@ -8,6 +8,7 @@ import random
 import signal
 import socket
 from collections import namedtuple
+from itertools import zip_longest
 
 import gevent.backdoor
 import gevent.event
@@ -112,15 +113,32 @@ def format_job(job):
 	)
 
 
-def generate_full_description(description, chapter_markers):
-	"""Assembles a full video description from its input parts.
-	Shared logic between cutting and updating jobs."""
-	parts = [description]
+def markers_to_video_times(chapter_markers, video_ranges, video_transitions):
+	"""Resolves chapter markers to a sequence of (video time in seconds, name)"""
+	chapter_markers = list(chapter_markers)
+	range_start_video_time = 0
+	for index, (video_range, transition_out) in enumerate(zip_longest(video_ranges, video_transitions)):
+		while chapter_markers and chapter_markers[0].video_range <= index:
+			chapter = chapter_markers.pop(0)
+			assert chapter.video_range == index, "Chapter markers not in order"
+			assert video_range.start <= chapter.time <= video_range.end, "Chapter marker not in time range"
+			video_time = range_start_video_time + (chapter.time - video_range.start).total_seconds()
+			yield (video_time, chapter.name)
+		range_start_video_time += (video_range.end - video_range.start).total_seconds()
+		if transition_out:
+			range_start_video_time -= transition_out.duration
+	assert not chapter_markers, "Chapter markers contain non-existent video ranges"
 
-	if chapter_markers is not None:
-		over_an_hour = any(ch.time >= datetime.timedelta(hours=1) for ch in chapter_markers)
+
+def generate_full_description(job):
+	"""Assembles a full video description from its input parts.
+	Shared logic between cutting and updating jobs - job can be a CutJob or an UpdateJob."""
+	parts = [job.video_description]
+
+	if job.chapter_markers is not None:
+		over_an_hour = get_duration(job) >= datetime.timedelta(hours=1)
 		def format_time(time):
-			hours, rest = divmod(time.total_seconds(), 3600)
+			hours, rest = divmod(time, 3600)
 			minutes, seconds = divmod(rest, 60)
 			hours = int(hours)
 			minutes = int(minutes)
@@ -132,8 +150,8 @@ def generate_full_description(description, chapter_markers):
 				return f"{minutes:02d}:{seconds:02d}"
 
 		parts.append("\n".join([
-			f"{format_time(chapter.time)} - {chapter.name}"
-			for chapter in chapter_markers
+			f"{format_time(time)} - {name}"
+			for time, name in markers_to_video_times(job.chapter_markers, job.video_ranges, job.video_transitions)
 		]))
 
 	return "\n\n".join(parts)
@@ -522,7 +540,7 @@ class Cutter(object):
 			try:
 				video_id, video_link = upload_backend.upload_video(
 					title=job.video_title,
-					description=generate_full_description(job.video_description, job.chapter_markers),
+					description=generate_full_description(job),
 					# Merge static and video-specific tags
 					tags=list(set(self.tags + job.video_tags)),
 					public=job.public,
@@ -802,7 +820,7 @@ class VideoUpdater(object):
 					try:
 						# Update video metadata
 						tags = list(set(self.tags + job.video_tags))
-						description = generate_full_description(job.video_description, job.chapter_markers)
+						description = generate_full_description(job)
 						self.backend.update_video(job.video_id, job.video_title, description, tags, job.public)
 
 						# Update thumbnail if needed. This might fail if we don't have the right segments,

--- a/cutter/cutter/main.py
+++ b/cutter/cutter/main.py
@@ -66,6 +66,7 @@ CUT_JOB_PARAMS = [
 	"video_transitions",
 	"video_title",
 	"video_description",
+	"chapter_markers",
 	"video_tags",
 	"video_channel",
 	"video_quality",
@@ -109,6 +110,33 @@ def format_job(job):
 		start=job.video_ranges[0].start.isoformat(),
 		duration=get_duration(job),
 	)
+
+
+def generate_full_description(description, chapter_markers):
+	"""Assembles a full video description from its input parts.
+	Shared logic between cutting and updating jobs."""
+	parts = [description]
+
+	if chapter_markers is not None:
+		over_an_hour = any(ch.time >= datetime.timedelta(hours=1) for ch in chapter_markers)
+		def format_time(time):
+			hours, rest = divmod(time.total_seconds(), 3600)
+			minutes, seconds = divmod(rest, 60)
+			hours = int(hours)
+			minutes = int(minutes)
+			seconds = int(seconds)
+			if over_an_hour:
+				return f"{hours:d}:{minutes:02d}:{seconds:02d}"
+			else:
+				assert hours == 0
+				return f"{minutes:02d}:{seconds:02d}"
+
+		parts.append("\n".join([
+			f"{format_time(chapter.time)} - {chapter.name}"
+			for chapter in chapter_markers
+		]))
+
+	return "\n\n".join(parts)
 
 
 class CandidateGone(Exception):
@@ -494,7 +522,7 @@ class Cutter(object):
 			try:
 				video_id, video_link = upload_backend.upload_video(
 					title=job.video_title,
-					description=job.video_description,
+					description=generate_full_description(job.video_description, job.chapter_markers),
 					# Merge static and video-specific tags
 					tags=list(set(self.tags + job.video_tags)),
 					public=job.public,
@@ -721,6 +749,7 @@ UPDATE_JOB_PARAMS = [
 	"video_quality",
 	"video_title",
 	"video_description",
+	"chapter_markers",
 	"video_tags",
 	"public",
 	"thumbnail_mode",
@@ -773,7 +802,8 @@ class VideoUpdater(object):
 					try:
 						# Update video metadata
 						tags = list(set(self.tags + job.video_tags))
-						self.backend.update_video(job.video_id, job.video_title, job.video_description, tags, job.public)
+						description = generate_full_description(job.video_description, job.chapter_markers)
+						self.backend.update_video(job.video_id, job.video_title, description, tags, job.public)
 
 						# Update thumbnail if needed. This might fail if we don't have the right segments,
 						# but that should be very rare and can be dealt with out of band.

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -43,6 +43,18 @@ CREATE TYPE end_time AS (
 	value TIMESTAMP
 );
 
+-- Represents a chapter marker for a video.
+-- Do not use this type directly, but rather the associated domain type.
+CREATE TYPE _chapter_marker AS (
+	time INTERVAL,
+	name TEXT
+);
+
+-- The chapter marker type, but with fields non-NULL.
+CREATE DOMAIN chapter_marker AS _chapter_marker CHECK (
+	(VALUE).time IS NOT NULL AND (VALUE).name IS NOT NULL
+);
+
 -- Each row on the sheet is an event.
 CREATE TABLE events (
 	-- id is generated and attached to rows in the sheet to uniquely identify them
@@ -130,6 +142,17 @@ CREATE TABLE events (
 	video_title TEXT CHECK (state IN ('UNEDITED', 'DONE') OR video_title IS NOT NULL),
 	-- The video description. Defaults to the sheet description.
 	video_description TEXT CHECK (state IN ('UNEDITED', 'DONE') OR video_description IS NOT NULL),
+	-- An optional list of chapter markers for the video. Generally this is appended to the description.
+	-- This is a list of times within the video (ie. duration since start of video) plus a title.
+	-- If non-NULL, the list must be non-empty, not contain nulls, and the first time must be 0 (ie. start of video).
+	chapter_markers chapter_marker[] CHECK (
+		chapter_markers IS NULL
+		OR (
+			CARDINALITY(chapter_markers) > 0 -- non-empty
+			AND array_position(chapter_markers, NULL) IS NULL -- no element is null
+			AND (chapter_markers[1]).time = '0'::INTERVAL -- first element has time 0
+		)
+	),
 	-- Tags to set on the video. Defaults to the sheet tags, plus a preset list.
 	video_tags TEXT[] CHECK (state IN ('UNEDITED', 'DONE') OR video_tags IS NOT NULL),
 	-- The twitch channel to cut the video from.

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -46,13 +46,20 @@ CREATE TYPE end_time AS (
 -- Represents a chapter marker for a video.
 -- Do not use this type directly, but rather the associated domain type.
 CREATE TYPE _chapter_marker AS (
-	time INTERVAL,
+	-- Index into video_ranges of the range this marker falls in.
+	-- Required as time may fall in multiple video ranges.
+	video_range INTEGER,
+	-- The timestamp of the marker. Must be within the video range.
+	time TIMESTAMP,
+	-- The chapter name.
 	name TEXT
 );
 
 -- The chapter marker type, but with fields non-NULL.
 CREATE DOMAIN chapter_marker AS _chapter_marker CHECK (
-	(VALUE).time IS NOT NULL AND (VALUE).name IS NOT NULL
+	(VALUE).video_range IS NOT NULL
+	AND (VALUE).time IS NOT NULL
+	AND (VALUE).name IS NOT NULL
 );
 
 -- Each row on the sheet is an event.
@@ -143,14 +150,15 @@ CREATE TABLE events (
 	-- The video description. Defaults to the sheet description.
 	video_description TEXT CHECK (state IN ('UNEDITED', 'DONE') OR video_description IS NOT NULL),
 	-- An optional list of chapter markers for the video. Generally this is appended to the description.
-	-- This is a list of times within the video (ie. duration since start of video) plus a title.
-	-- If non-NULL, the list must be non-empty, not contain nulls, and the first time must be 0 (ie. start of video).
+	-- This is a list of (video range index, timestamp) along with a name. The range index is needed to
+	-- uniquely identify the time in the video as the timestamp alone may be ambiguous.
+	-- If non-NULL, the list must be non-empty and not contain nulls, and video_ranges must be non-NULL.
 	chapter_markers chapter_marker[] CHECK (
 		chapter_markers IS NULL
 		OR (
 			CARDINALITY(chapter_markers) > 0 -- non-empty
 			AND array_position(chapter_markers, NULL) IS NULL -- no element is null
-			AND (chapter_markers[1]).time = '0'::INTERVAL -- first element has time 0
+			AND video_ranges IS NOT NULL
 		)
 	),
 	-- Tags to set on the video. Defaults to the sheet tags, plus a preset list.

--- a/thrimshim/thrimshim/main.py
+++ b/thrimshim/thrimshim/main.py
@@ -343,8 +343,8 @@ def update_row(ident, editor=None):
 		'video_channel', 'video_quality', 'video_tags', 'thumbnail_mode', 'public'
 	]
 	edit_columns = non_null_edit_columns + [
-		'allow_holes', 'uploader_whitelist', 'thumbnail_time', 'thumbnail_template',
-		'thumbnail_image', 'thumbnail_crop', 'thumbnail_location',
+		'chapter_markers', 'allow_holes', 'uploader_whitelist', 'thumbnail_time',
+		'thumbnail_template', 'thumbnail_image', 'thumbnail_crop', 'thumbnail_location',
 	]
 	sheet_columns = [
 		'sheet_name', 'event_start', 'event_end',
@@ -353,7 +353,7 @@ def update_row(ident, editor=None):
 	# These columns may be modified when a video is in state 'DONE',
 	# and are a subset of edit_columns.
 	modifiable_columns = [
-		'video_title', 'video_description', 'video_tags', 'public',
+		'video_title', 'video_description', 'chapter_markers', 'video_tags', 'public',
 		'thumbnail_mode', 'thumbnail_time', 'thumbnail_template',
 		'thumbnail_image', 'thumbnail_crop', 'thumbnail_location',
 	]
@@ -459,6 +459,12 @@ def update_row(ident, editor=None):
 			new_row['video_transitions'] = [
 				None if transition is None else tuple(transition)
 				for transition in new_row['video_transitions']
+			]
+
+		if new_row.get('chapter_markers') is not None:
+			new_row['chapter_markers'] = [
+				(datetime.timedelta(seconds=time), name)
+				for time, name in new_row['chapter_markers']
 			]
 
 		# Convert binary fields from base64 and do basic validation of contents

--- a/thrimshim/thrimshim/main.py
+++ b/thrimshim/thrimshim/main.py
@@ -463,8 +463,7 @@ def update_row(ident, editor=None):
 
 		if new_row.get('chapter_markers') is not None:
 			new_row['chapter_markers'] = [
-				(datetime.timedelta(seconds=time), name)
-				for time, name in new_row['chapter_markers']
+				tuple(marker) for marker in new_row['chapter_markers']
 			]
 
 		# Convert binary fields from base64 and do basic validation of contents


### PR DESCRIPTION
instead of the editor automatically appending them to the description.

This adds an edit column "chapter_markers" containing a list of (time, name).
The time is a time interval from video start (eg. 1 minute 23 seconds) and the name is the chapter name.

The chapter markers are appended to the description automatically during cutting,
and can be modified by the usual method.