### PR TITLE
Dobby/sup reminders

### DIFF
--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -345,6 +345,22 @@
     ],
   },
 
+  // schedulebot reminders
+  reminders:: [
+    // Example reminder
+    //{
+    //  stream: "general",
+    //  topic: "Important reminders",
+    //  hours: [0, 12],
+    //  text: |||
+    //    It's time to...
+    //    ```spoiler Time to what?
+    //    **ROTATE THE CUSHIONS**
+    //    ```
+    //  |||,
+    //},
+  ],
+
   tootbot:: {
     zulip: {
       email: "tootbot-bot@chat.videostrike.team",
@@ -840,7 +856,15 @@
         start_time: $.bustime_start,
         schedule: "/schedule",
         google_credentials_file: "/creds.json",
-      }, $.schedulebot.args) + {
+      }, $.schedulebot.args + [
+        "--reminder=%s:%s:%s:%s" % [
+        r.stream,
+        r.topic,
+        std.join(",", std.map(std.toString, r.hours)),
+        r.text,
+        ]
+        for r in $.reminders
+      ]) + {
         volumes: ["%s:/creds.json" % $.schedulebot.google_credentials_file],
       },
 

--- a/zulip_bots/zulip_bots/schedulebot.py
+++ b/zulip_bots/zulip_bots/schedulebot.py
@@ -76,7 +76,7 @@ def update_groups(client, group_ids, schedule, hour, start_time, last):
 
 def hour_to_shift(hour, start_time, shift_definitions):
 	"""Converts an hour number into a datetime, shift emoji name, and hour-of-shift (1-6)"""
-	start_time = datetime.utcfromtimestamp(start_time)
+	start_time = datetime.fromtimestamp(start_time, timezone("utc"))
 	current_time = (start_time + timedelta(hours=hour)).replace(minute=0, second=0, microsecond=0)
 	shifts = parse_shifts(shift_definitions) # need to do this each hour to check for Omega shift start time
 	shift, shift_hour = calculate_shift(current_time, shifts)

--- a/zulip_bots/zulip_bots/schedulebot.py
+++ b/zulip_bots/zulip_bots/schedulebot.py
@@ -17,6 +17,7 @@ import time
 from calendar import timegm
 from datetime import datetime, timedelta
 from pytz import timezone
+from collections import namedtuple
 
 import gevent.pool
 import argh
@@ -245,22 +246,27 @@ def parse_schedule(sheets_client, user_ids, schedule_sheet_id, schedule_sheet_na
 	return schedule
 
 
+Reminder = namedtuple("Reminder", ["times", "stream", "topic", "text"])
 def parse_reminders(reminder_strings: list[str]):
 	reminders = list()
 	for reminder_string in reminder_strings:
 		stream, topic, timespec, text = reminder_string.split(':', 3)
 		times = [int(t) for t in timespec.split(',')]
-		reminders.append((times, stream, topic, text))
+		reminders.append(Reminder(times, stream, topic, text))
 	return reminders
 
 
-def check_reminders(reminders, send_client):
-	moonbase_hour = datetime.now(timezone("America/Vancouver")).hour
+def check_reminders(reminders: list[Reminder], hour, start_time, send_client):
+	if hour < 0: return # Don't send reminders before the run starts
+	moonbase_start = datetime.fromtimestamp(start_time, timezone("America/Vancouver"))
+	moonbase_hour = (moonbase_start + timedelta(hours=hour)).replace(minute=0, second=0, microsecond=0).hour
 	for reminder in reminders:
-		if moonbase_hour in reminder[0]:
-			send_client.send_to_stream(reminder[1], reminder[2], reminder[3])
+		if moonbase_hour in reminder.times:
+			send_client.send_to_stream(reminder.stream, reminder.topic, reminder.text)
 
 
+
+@argh.arg("--reminder", action="append", metavar="STREAM:TOPIC:HOUR{,HOUR}:TEXT")
 def main(conf_file, hour=-1, no_groups=False, stream="General", no_mentions=False, no_initial=False, shifts=None, last=-1, metrics_port=8012, reminder: list[str] = None):
 	"""
 	config:
@@ -306,7 +312,7 @@ def main(conf_file, hour=-1, no_groups=False, stream="General", no_mentions=Fals
 		config["schedule_sheet_id"],
 		config["schedule_sheet_name"]
 	)
-	reminders = parse_reminders(reminder)
+	reminders = parse_reminders(reminder or [])
 
 	# Accept start time timestamp with or without trailing "Z" indicating UTC.
 	start_time = config["start_time"]
@@ -342,7 +348,7 @@ def main(conf_file, hour=-1, no_groups=False, stream="General", no_mentions=Fals
 			if stream:
 				post_schedule(client, send_client, start_time, schedule, stream, hour, no_mentions, last, shifts)
 		no_initial = False
-		check_reminders(reminders, send_client)
+		check_reminders(reminders, hour, start_time, send_client)
 		next_hour = start_time + 3600 * (hour + 1)
 		remaining = next_hour - time.time()
 		if remaining > 0:

--- a/zulip_bots/zulip_bots/schedulebot.py
+++ b/zulip_bots/zulip_bots/schedulebot.py
@@ -16,7 +16,7 @@ import logging
 import time
 from calendar import timegm
 from datetime import datetime, timedelta
-import pytz
+from pytz import timezone
 
 import gevent.pool
 import argh
@@ -255,7 +255,7 @@ def parse_reminders(reminder_strings: list[str]):
 
 
 def check_reminders(reminders, send_client):
-	moonbase_hour = datetime.now(pytz.timezone("America/Vancouver")).hour
+	moonbase_hour = datetime.now(timezone("America/Vancouver")).hour
 	for reminder in reminders:
 		if moonbase_hour in reminder[0]:
 			send_client.send_to_stream(reminder[1], reminder[2], reminder[3])

--- a/zulip_bots/zulip_bots/schedulebot.py
+++ b/zulip_bots/zulip_bots/schedulebot.py
@@ -16,6 +16,7 @@ import logging
 import time
 from calendar import timegm
 from datetime import datetime, timedelta
+import pytz
 
 import gevent.pool
 import argh
@@ -244,7 +245,23 @@ def parse_schedule(sheets_client, user_ids, schedule_sheet_id, schedule_sheet_na
 	return schedule
 
 
-def main(conf_file, hour=-1, no_groups=False, stream="General", no_mentions=False, no_initial=False, shifts=None, last=-1, metrics_port=8012):
+def parse_reminders(reminder_strings: list[str]):
+	reminders = list()
+	for reminder_string in reminder_strings:
+		stream, topic, timespec, text = reminder_string.split(':', 3)
+		times = [int(t) for t in timespec.split(',')]
+		reminders.append((times, stream, topic, text))
+	return reminders
+
+
+def check_reminders(reminders, send_client):
+	moonbase_hour = datetime.now(pytz.timezone("America/Vancouver")).hour
+	for reminder in reminders:
+		if moonbase_hour in reminder[0]:
+			send_client.send_to_stream(reminder[1], reminder[2], reminder[3])
+
+
+def main(conf_file, hour=-1, no_groups=False, stream="General", no_mentions=False, no_initial=False, shifts=None, last=-1, metrics_port=8012, reminder: list[str] = None):
 	"""
 	config:
 		url: the base url of the instance
@@ -289,6 +306,7 @@ def main(conf_file, hour=-1, no_groups=False, stream="General", no_mentions=Fals
 		config["schedule_sheet_id"],
 		config["schedule_sheet_name"]
 	)
+	reminders = parse_reminders(reminder)
 
 	# Accept start time timestamp with or without trailing "Z" indicating UTC.
 	start_time = config["start_time"]
@@ -324,6 +342,7 @@ def main(conf_file, hour=-1, no_groups=False, stream="General", no_mentions=Fals
 			if stream:
 				post_schedule(client, send_client, start_time, schedule, stream, hour, no_mentions, last, shifts)
 		no_initial = False
+		check_reminders(reminders, send_client)
 		next_hour = start_time + 3600 * (hour + 1)
 		remaining = next_hour - time.time()
 		if remaining > 0:


### PR DESCRIPTION
Initial implementation of reminders in schedulebot, resolves #503 

Reminders are added in the docker-compose.jsonnet file, in the args array:
`"--reminder", "general:reminders:1,3,5,7,9,11,13,15,17,19,21,23:Hydrate everybody!", "general:reminders:0:Jock Jams!"`

A reminder is formated as `STREAM:TOPIC:TIMESPEC:TEXT`, with timespec being a comma separated list of moonbase hours [0-23].

Possible further improvements:
Allowing reminders to be triggered at times outside a full hour (maybe switch timespec to a cron-like format?)
maybe cleaning up the reminder accessing in check_reminders so that we're not accessing "random" indexes, but I'm not really sure about a neat way to do that in python.